### PR TITLE
feat(refactor): disable identities on networks where People Chain is being used

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -38,3 +38,8 @@ export const MaxPayoutDays = 60;
 export const MaxEraRewardPointsEras = 10;
 export const ZondaxMetadataHashApiUrl =
   'https://api.zondax.ch/polkadot/node/metadata/hash';
+
+/*
+ * People Chain migration - disallow identities on networks where People Chain is live.
+ */
+export const PeopleChainNetworks = ['westend', 'kusama'];

--- a/src/contexts/Validators/ValidatorEntries/index.tsx
+++ b/src/contexts/Validators/ValidatorEntries/index.tsx
@@ -9,7 +9,7 @@ import type { AnyApi, Fn } from 'types';
 import { useEffectIgnoreInitial } from '@w3ux/hooks';
 import { useNetwork } from 'contexts/Network';
 import { useApi } from 'contexts/Api';
-import { MaxEraRewardPointsEras } from 'consts';
+import { MaxEraRewardPointsEras, PeopleChainNetworks } from 'consts';
 import { useStaking } from 'contexts/Staking';
 import type {
   EraPointsBoundaries,
@@ -316,14 +316,17 @@ export const ValidatorsProvider = ({ children }: { children: ReactNode }) => {
     // NOTE: validators are shuffled before committed to state.
     setValidators(shuffle(validatorEntries));
 
-    const addresses = validatorEntries.map(({ address }) => address);
-    const { identities, supers } = await IdentitiesController.fetch(
-      api,
-      addresses
-    );
+    // PEOPLE CHAIN MIGRATION: Currently ignoring identities while People Chain is not supported.
+    if (!PeopleChainNetworks.includes(network)) {
+      const addresses = validatorEntries.map(({ address }) => address);
+      const { identities, supers } = await IdentitiesController.fetch(
+        api,
+        addresses
+      );
+      setValidatorIdentities(identities);
+      setValidatorSupers(supers);
+    }
 
-    setValidatorIdentities(identities);
-    setValidatorSupers(supers);
     setValidatorsFetched('synced');
   };
 

--- a/src/controllers/ActivePoolsController/index.ts
+++ b/src/controllers/ActivePoolsController/index.ts
@@ -16,6 +16,7 @@ import type {
 import { SyncController } from 'controllers/SyncController';
 import type { Nominations } from 'contexts/Balances/types';
 import type { ApiPromise } from '@polkadot/api';
+import { PeopleChainNetworks } from 'consts';
 
 export class ActivePoolsController {
   // ------------------------------------------------------
@@ -126,11 +127,16 @@ export class ActivePoolsController {
     const balance = accountDataResult.data;
     const rewardAccountBalance = balance?.free.toString();
 
-    // Fetch identities for roles and expand `bondedPool` state to store them.
-    bondedPool.roleIdentities = await IdentitiesController.fetch(
-      api,
-      this.getUniqueRoleAddresses(bondedPool.roles)
-    );
+    // PEOPLE CHAIN MIGRATION: Currently ignoring identities while People Chain is not supported.
+    if (
+      !PeopleChainNetworks.includes(api.runtimeChain.toString().toLowerCase())
+    ) {
+      // Fetch identities for roles and expand `bondedPool` state to store them.
+      bondedPool.roleIdentities = await IdentitiesController.fetch(
+        api,
+        this.getUniqueRoleAddresses(bondedPool.roles)
+      );
+    }
 
     // Only persist the active pool to class state (and therefore dispatch an event) if both the
     // bonded pool and reward pool are returned.


### PR DESCRIPTION
This PR disables identity fetches on westend and kusama, in preparation to using the People Chain instead. The changes here will fix an issue where Kusama nomination pools were not being updated.