### PR TITLE
feat: Check if Polkadot app is at least generic version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "buffer": "^6.0.3",
     "chart.js": "^4.4.3",
     "chroma-js": "^2.4.2",
+    "compare-versions": "^6.1.1",
     "date-fns": "^3.3.1",
     "framer-motion": "^11.2.10",
     "html5-qrcode": "^2.3.8",

--- a/src/contexts/LedgerHardware/index.tsx
+++ b/src/contexts/LedgerHardware/index.tsx
@@ -18,6 +18,7 @@ import type {
 } from './types';
 import { Ledger } from './static/ledger';
 import type { AnyJson } from '@w3ux/types';
+import { compare } from 'compare-versions';
 
 export const LedgerHardwareContext =
   createContext<LedgerHardwareContextInterface>(defaultLedgerHardwareContext);
@@ -93,11 +94,24 @@ export const LedgerHardwareProvider = ({
       const { app } = await Ledger.initialise(txMetadataChainId);
       const result = await Ledger.getVersion(app);
       const major = result?.major || 0;
+      const minor = result?.minor || 0;
+      const patch = result?.major || 0;
+
+      // The current version of the Polkadot Ledger app.
+      const currentSemVer = `${major}.${minor}.${patch}`;
+
+      // The version the Generic Polkadot Ledger app was introduced.
+      const genericLaunchSemVer = '100.0.5';
+
+      // Check if the current version is upgraded for the Generic Polkadot Ledger app.
+      const isLegacy = compare(currentSemVer, genericLaunchSemVer, '<');
 
       setIsExecuting(false);
       resetFeedback();
 
-      if (major < transactionVersion) {
+      // If the current version is less than the transaction version, or the app is not the generic
+      // app, set the runtimesInconsistent flag.
+      if (major < transactionVersion || isLegacy) {
         runtimesInconsistent.current = true;
       }
       setIntegrityChecked(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3564,6 +3564,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compare-versions@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "compare-versions@npm:6.1.1"
+  checksum: 10c0/415205c7627f9e4f358f571266422980c9fe2d99086be0c9a48008ef7c771f32b0fbe8e97a441ffedc3910872f917a0675fe0fe3c3b6d331cda6d8690be06338
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -6468,6 +6475,7 @@ __metadata:
     buffer: "npm:^6.0.3"
     chart.js: "npm:^4.4.3"
     chroma-js: "npm:^2.4.2"
+    compare-versions: "npm:^6.1.1"
     date-fns: "npm:^3.3.1"
     eslint: "npm:8.57.0"
     eslint-config-prettier: "npm:^9.1.0"


### PR DESCRIPTION
Fails the "runtime check" stage of a Ledger device if the Polkadot Ledger app version is not at least the version when generic support was introduced.

Uses `compare-versions` for semVer comparison.