### PR TITLE
feat(refactor): People chain on Polkadot - disable identities on Relay Chain

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -42,4 +42,4 @@ export const ZondaxMetadataHashApiUrl =
 /*
  * People Chain migration - disallow identities on networks where People Chain is live.
  */
-export const PeopleChainNetworks = ['westend', 'kusama'];
+export const PeopleChainNetworks = ['polkadot', 'westend', 'kusama'];


### PR DESCRIPTION
Disables identities on the Polkadot Relay Chain as identities are migrated. A future PR will add identities support back via the People system chain.