### PR TITLE
feat(refactor): Remove pre-paged rewards deprecation logic

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -10,24 +10,8 @@ import WestendInlineSVG from 'img/westend_inline.svg?react';
 import PolkadotTokenSVG from 'config/tokens/svg/DOT.svg?react';
 import KusamaTokenSVG from 'config/tokens/svg/KSM.svg?react';
 import WestendTokenSVG from 'config/tokens/svg/WND.svg?react';
-
-import type { NetworkName, Networks } from 'types';
+import type { Networks } from 'types';
 import BigNumber from 'bignumber.js';
-
-// DEPRECATION: Paged Rewards
-//
-// Temporary until paged rewards migration has completed on all networks. Wait 84 eras from Polkadot
-// start: 1420 + 84 = 1504, when full history depth will be moved over to new paged rewards storage.
-export const NetworksWithPagedRewards: NetworkName[] = [
-  'polkadot',
-  'kusama',
-  'westend',
-];
-export const PagedRewardsStartEra: Record<NetworkName, BigNumber | null> = {
-  polkadot: new BigNumber(1420),
-  kusama: new BigNumber(6514),
-  westend: new BigNumber(7167),
-};
 
 export const NetworkList: Networks = {
   polkadot: {

--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -87,5 +87,4 @@ export const defaultApiContext: APIContextInterface = {
   activeEra: defaultActiveEra,
   poolsConfig: defaultPoolsConfig,
   stakingMetrics: defaultStakingMetrics,
-  isPagedRewardsActive: (e) => false,
 };

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -3,11 +3,7 @@
 
 import { setStateWithRef } from '@w3ux/utils';
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
-import {
-  NetworkList,
-  NetworksWithPagedRewards,
-  PagedRewardsStartEra,
-} from 'config/networks';
+import { NetworkList } from 'config/networks';
 
 import type {
   APIActiveEra,
@@ -355,18 +351,6 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
     }
   };
 
-  // Given an era, determine whether paged rewards are active.
-  const isPagedRewardsActive = (era: BigNumber): boolean => {
-    const networkStartEra = PagedRewardsStartEra[network];
-    if (!networkStartEra) {
-      return false;
-    }
-    return (
-      NetworksWithPagedRewards.includes(network) &&
-      era.isGreaterThanOrEqualTo(networkStartEra)
-    );
-  };
-
   const reInitialiseApi = async (type: ConnectionType) => {
     setApiStatus('disconnected');
 
@@ -462,7 +446,6 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
         activeEra,
         poolsConfig,
         stakingMetrics,
-        isPagedRewardsActive,
       }}
     >
       {children}

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -85,5 +85,4 @@ export interface APIContextInterface {
   activeEra: APIActiveEra;
   poolsConfig: APIPoolsConfig;
   stakingMetrics: APIStakingMetrics;
-  isPagedRewardsActive: (era: BigNumber) => boolean;
 }

--- a/src/contexts/Pools/PoolPerformance/index.tsx
+++ b/src/contexts/Pools/PoolPerformance/index.tsx
@@ -12,7 +12,6 @@ import { useApi } from 'contexts/Api';
 import BigNumber from 'bignumber.js';
 import { mergeDeep, setStateWithRef } from '@w3ux/utils';
 import { useStaking } from 'contexts/Staking';
-import { formatRawExposures } from 'contexts/Staking/Utils';
 import type {
   PoolPerformanceContextInterface,
   PoolPerformanceTasks,
@@ -39,9 +38,9 @@ export const PoolPerformanceProvider = ({
   children: ReactNode;
 }) => {
   const { network } = useNetwork();
+  const { api, activeEra } = useApi();
   const { getPagedErasStakers } = useStaking();
   const { erasRewardPoints } = useValidators();
-  const { api, activeEra, isPagedRewardsActive } = useApi();
 
   // Store  pool performance task data under a given key as it is being fetched . NOTE: Requires a
   // ref to be accessed in `processEra` before re-render.
@@ -187,19 +186,7 @@ export const PoolPerformanceProvider = ({
     // NOTE: This will not make any difference on the first run.
     updateTaskCurrentEra(key, era);
 
-    let exposures;
-    if (isPagedRewardsActive(era)) {
-      exposures = await getPagedErasStakers(era.toString());
-    } else {
-      // DEPRECATION: Paged Rewards
-      //
-      // Use deprecated `erasStakersClipped` if paged rewards not active for this era.
-      const result = await api.query.staking.erasStakersClipped.entries(
-        era.toString()
-      );
-      exposures = formatRawExposures(result);
-    }
-
+    const exposures = await getPagedErasStakers(era.toString());
     const addresses = tasksRef.current[key]?.addresses || [];
 
     worker.postMessage({


### PR DESCRIPTION
A sufficient amount of eras have now passed to no longer consider the legacy `erasStakers` storage that was used prior to paged rewards. Cleans the codebase of pre-paged rewards code, and removes logic pertaining to the deprecation.