### PR TITLE
fix: other account duplicate when added to extension

### DIFF
--- a/src/contexts/Connect/OtherAccounts/index.tsx
+++ b/src/contexts/Connect/OtherAccounts/index.tsx
@@ -69,9 +69,12 @@ export const OtherAccountsProvider = ({
         setOtherAccounts,
         otherAccountsRef
       );
-      // If the currently active account is being forgotten, disconnect.
+      // If the currently active account is being forgotten, and it is not present in extension
+      // accounts, disconnect.
       if (
-        forget.find(({ address }) => address === activeAccount) !== undefined
+        forget.find(({ address }) => address === activeAccount) !== undefined &&
+        extensionAccounts.find(({ address }) => address === activeAccount) ===
+          undefined
       ) {
         setActiveAccount(null);
       }


### PR DESCRIPTION
Fixes an issue where an account imported via `OtherAccountsProvider` would also be imported in a web extension after the fact, resulting in a duplicate entry. Dashboard will now remove duplicate entries from `OtherAccounts`.