### PR TITLE
feat: Replace `maxElectingVoters` const with `counterForNominators` storage

### DIFF
--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -34,7 +34,6 @@ export const defaultConsts: APIConstants = {
   sessionsPerEra: new BigNumber(0),
   maxExposurePageSize: new BigNumber(0),
   historyDepth: new BigNumber(0),
-  maxElectingVoters: new BigNumber(0),
   expectedBlockTime: new BigNumber(0),
   epochDuration: new BigNumber(0),
   existentialDeposit: new BigNumber(0),
@@ -77,6 +76,7 @@ export const defaultStakingMetrics: APIStakingMetrics = {
   maxValidatorsCount: new BigNumber(0),
   minNominatorBond: new BigNumber(0),
   totalStaked: new BigNumber(0),
+  counterForNominators: new BigNumber(0),
 };
 
 export const defaultApiContext: APIContextInterface = {

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -283,7 +283,6 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
 
         setConsts({
           maxNominations: new BigNumber(16),
-          maxElectingVoters: new BigNumber(22500),
           bondDuration: new BigNumber(bondingDuration),
           sessionsPerEra: new BigNumber(sessionsPerEra),
           maxExposurePageSize: new BigNumber(maxExposurePageSize),

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -22,7 +22,6 @@ export interface APIConstants {
   sessionsPerEra: BigNumber;
   maxExposurePageSize: BigNumber;
   historyDepth: BigNumber;
-  maxElectingVoters: BigNumber;
   expectedBlockTime: BigNumber;
   epochDuration: BigNumber;
   existentialDeposit: BigNumber;
@@ -65,6 +64,7 @@ export interface APIStakingMetrics {
   maxValidatorsCount: BigNumber;
   minNominatorBond: BigNumber;
   totalStaked: BigNumber;
+  counterForNominators: BigNumber;
 }
 
 export interface APIContextInterface {

--- a/src/model/Observables/ChainSpec.ts
+++ b/src/model/Observables/ChainSpec.ts
@@ -81,7 +81,6 @@ export class ChainSpec implements ObservableGetSubscription {
   // Unsubscribe from class subscription.
   unsubscribe = (): void => {
     if (typeof this.#unsub === 'function') {
-      console.log('UNSUBSCRIBING FROM CHAINSPEC');
       this.#unsub();
     }
   };

--- a/src/model/Query/NetworkMeta/index.ts
+++ b/src/model/Query/NetworkMeta/index.ts
@@ -42,6 +42,7 @@ export class NetworkMeta {
       [api.query.staking.erasTotalStake, previousEra.toString()],
       api.query.staking.minNominatorBond,
       [api.query.staking.erasTotalStake, activeEra.index.toString()],
+      api.query.staking.counterForNominators,
     ]);
 
     // format optional configs to BigNumber or null.
@@ -90,6 +91,7 @@ export class NetworkMeta {
         lastTotalStake: stringToBn(networkMeta[20].toString()),
         minNominatorBond: stringToBn(networkMeta[21].toString()),
         totalStaked: stringToBn(networkMeta[22].toString()),
+        counterForNominators: stringToBn(networkMeta[23].toString()),
       },
     };
   }

--- a/src/model/Subscribe/StakingMetrics/index.ts
+++ b/src/model/Subscribe/StakingMetrics/index.ts
@@ -66,6 +66,7 @@ export class StakingMetrics implements Unsubscribable {
               api.query.staking.erasTotalStake,
               this.#activeEra.index.toString(),
             ],
+            api.query.staking.counterForNominators,
           ],
           (result) => {
             const stakingMetrics = {
@@ -77,6 +78,7 @@ export class StakingMetrics implements Unsubscribable {
               lastTotalStake: stringToBn(result[5].toString()),
               minNominatorBond: stringToBn(result[6].toString()),
               totalStaked: stringToBn(result[7].toString()),
+              counterForNominators: stringToBn(result[8].toString()),
             };
 
             document.dispatchEvent(

--- a/src/pages/Nominate/Active/Stats/ActiveNominators.tsx
+++ b/src/pages/Nominate/Active/Stats/ActiveNominators.tsx
@@ -9,27 +9,28 @@ import { Pie } from 'library/StatBoxList/Pie';
 
 export const ActiveNominatorsStat = () => {
   const { t } = useTranslation('pages');
-  const { consts } = useApi();
-  const { maxElectingVoters } = consts;
+  const {
+    stakingMetrics: { counterForNominators },
+  } = useApi();
   const { totalActiveNominators } = useStaking().eraStakers;
 
   // active nominators as percent
   let totalNominatorsAsPercent = 0;
-  if (maxElectingVoters.isGreaterThan(0)) {
+  if (counterForNominators.isGreaterThan(0)) {
     totalNominatorsAsPercent =
-      totalActiveNominators / maxElectingVoters.dividedBy(100).toNumber();
+      totalActiveNominators / counterForNominators.dividedBy(100).toNumber();
   }
 
   const params = {
     label: t('overview.activeNominators'),
     stat: {
       value: totalActiveNominators,
-      total: maxElectingVoters.toNumber(),
+      total: counterForNominators.toNumber(),
       unit: '',
     },
     graph: {
       value1: totalActiveNominators,
-      value2: maxElectingVoters.minus(totalActiveNominators).toNumber(),
+      value2: counterForNominators.minus(totalActiveNominators).toNumber(),
     },
     tooltip: `${new BigNumber(totalNominatorsAsPercent)
       .decimalPlaces(2)


### PR DESCRIPTION
`maxElectingVoters` has been discontinued on chain, now nominators are uncapped, and `counterForNominators` is being used as the upper nominator limit in the dashboard.