### PR TITLE
feat(fix): Render timeleft on `end` time update

### DIFF
--- a/src/hooks/useEraTimeLeft/index.tsx
+++ b/src/hooks/useEraTimeLeft/index.tsx
@@ -37,7 +37,7 @@ export const useEraTimeLeft = () => {
       ? new BigNumber(0)
       : new BigNumber(100).minus(percentRemaining);
 
-    return { timeleft, percentSurpassed, percentRemaining };
+    return { timeleft, end, percentSurpassed, percentRemaining };
   };
 
   return { get };

--- a/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
+++ b/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
@@ -23,7 +23,6 @@ export const ActiveEraStat = () => {
 
   // re-set timer on era change (also covers network change).
   useEffect(() => {
-    console.log('end: ', timeleftResult.end.toString());
     setFromNow(dateFrom, dateTo);
   }, [activeEra, timeleftResult.end.toString()]);
 

--- a/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
+++ b/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
@@ -17,16 +17,18 @@ export const ActiveEraStat = () => {
   const { get: getEraTimeleft } = useEraTimeLeft();
   const { timeleft, setFromNow } = useTimeLeft();
 
+  const timeleftResult = getEraTimeleft();
   const dateFrom = fromUnixTime(Date.now() / 1000);
-  const dateTo = fromNow(getEraTimeleft().timeleft.toNumber());
+  const dateTo = fromNow(timeleftResult.timeleft.toNumber());
 
   // re-set timer on era change (also covers network change).
   useEffect(() => {
+    console.log('end: ', timeleftResult.end.toString());
     setFromNow(dateFrom, dateTo);
-  }, [activeEra]);
+  }, [activeEra, timeleftResult.end.toString()]);
 
   // NOTE: this maybe should be called in an interval. Needs more testing.
-  const { percentSurpassed, percentRemaining } = getEraTimeleft();
+  const { percentSurpassed, percentRemaining } = timeleftResult;
 
   const params = {
     label: t('overview.timeRemainingThisEra'),


### PR DESCRIPTION
Fixes an issue where the end time of a timeleft UI would not re-render when the end time updates.