### PR TITLE
fix: Manage pools formatting error

### DIFF
--- a/packages/app/src/overlay/modals/ManagePool/Forms/ManageCommission/provider/index.tsx
+++ b/packages/app/src/overlay/modals/ManagePool/Forms/ManageCommission/provider/index.tsx
@@ -38,7 +38,7 @@ export const PoolCommissionProvider = ({
 
   // Get initial maximum commission value from the bonded pool commission config.
   const initialMaxCommission = Number(
-    (bondedPool?.commission?.max || '100%').slice(0, -1)
+    (bondedPool?.commission?.max || '100').toString().slice(0, -1)
   )
 
   // Get initial change rate value from the bonded pool commission config.


### PR DESCRIPTION
In [Dashboard ](https://staking.polkadot.cloud/#/pools) when open pools and clic to Manage, this error occurs:

`hook.js:608 TypeError: ((intermediate value)(intermediate value)(intermediate value) || "100%").slice is not a function
    at vpt (index-DX-H3mSL.js:7177:1080)
    at S0 (index-DX-H3mSL.js:2427:17990)
    at vS (index-DX-H3mSL.js:2429:45437)
    at pS (index-DX-H3mSL.js:2429:41047)
    at jk (index-DX-H3mSL.js:2429:40975)
    at wy (index-DX-H3mSL.js:2429:40826)
    at o3 (index-DX-H3mSL.js:2429:37070)
    at fS (index-DX-H3mSL.js:2429:37880)
    at Xd (index-DX-H3mSL.js:2427:3290)
    at index-DX-H3mSL.js:2429:35370`

And appear a modal with this message: `Oops, Something Went Wrong
Click to reload`

For prevent this error, I fix the line 41 in `polkadot-staking-dashboard/packages/app/src/overlay/modals/ManagePool/Forms/ManageCommission/provider/index.tsx`

Please hurry up and accept the Merge request, because I have put my pool in Destroying state, and if this error is not fixed, the rest of the members will not be able to leave the pool.

Regards,