### PR TITLE
Fix show all members of pool

### DIFF
--- a/packages/app/src/controllers/Subscan/index.ts
+++ b/packages/app/src/controllers/Subscan/index.ts
@@ -169,7 +169,7 @@ export class Subscan {
         poolId: entry.pool_id,
       }))
       .reverse()
-      .splice(0, result.list.length - 1)
+      .splice(0, result.list.length)
   }
 
   // Fetch a pool's era points from Subscan.

--- a/packages/app/src/overlay/modals/ManagePool/Forms/ManageCommission/provider/index.tsx
+++ b/packages/app/src/overlay/modals/ManagePool/Forms/ManageCommission/provider/index.tsx
@@ -38,7 +38,7 @@ export const PoolCommissionProvider = ({
 
   // Get initial maximum commission value from the bonded pool commission config.
   const initialMaxCommission = Number(
-    (bondedPool?.commission?.max || '100%').slice(0, -1)
+    (bondedPool?.commission?.max || '100').toString().slice(0, -1)
   )
 
   // Get initial change rate value from the bonded pool commission config.


### PR DESCRIPTION
In [Dashboard in menu pools](https://staking.polkadot.cloud/#/pools), when click to show all members, for example if pool has 41 members, in the page of list of members only show 40 members.

The member lost, is the member with more Bonded Polkadots.

The second param of function splice() is the number of items, no the index of item.

[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice)