### PR TITLE
feat: Disable dual staking

### DIFF
--- a/packages/app/src/contexts/Pools/ActivePool/defaults.ts
+++ b/packages/app/src/contexts/Pools/ActivePool/defaults.ts
@@ -19,6 +19,7 @@ export const defaultPoolNominations = {
 }
 
 export const defaultActivePoolContext: ActivePoolContextState = {
+  inPool: () => false,
   isBonding: () => false,
   isNominator: () => false,
   isOwner: () => false,

--- a/packages/app/src/contexts/Pools/ActivePool/index.tsx
+++ b/packages/app/src/contexts/Pools/ActivePool/index.tsx
@@ -119,6 +119,9 @@ export const ActivePoolProvider = ({ children }: { children: ReactNode }) => {
     return String(membership?.poolId || '') === p
   }
 
+  // Returns whether the active account is in a pool.
+  const inPool = () => !!membership
+
   // Returns whether the active account is the depositor of the active pool.
   const isDepositor = () => {
     const roles = activePool?.bondedPool?.roles
@@ -170,6 +173,7 @@ export const ActivePoolProvider = ({ children }: { children: ReactNode }) => {
     <ActivePoolContext.Provider
       value={{
         isNominator,
+        inPool,
         isOwner,
         isMember,
         isDepositor,

--- a/packages/app/src/contexts/Pools/ActivePool/types.ts
+++ b/packages/app/src/contexts/Pools/ActivePool/types.ts
@@ -4,6 +4,7 @@
 import type { ActivePool, Nominations, PoolRoles, PoolUnlocking } from 'types'
 
 export interface ActivePoolContextState {
+  inPool: () => boolean
   isBonding: () => boolean
   isNominator: () => boolean
   isOwner: () => boolean

--- a/packages/app/src/library/CallToAction/index.tsx
+++ b/packages/app/src/library/CallToAction/index.tsx
@@ -145,8 +145,6 @@ export const CallToActionWrapper = styled.div`
             }
 
             &.disabled {
-              opacity: 0.5;
-
               &:hover {
                 filter: none;
               }
@@ -197,12 +195,13 @@ export const CallToActionWrapper = styled.div`
               margin-left: 0.75rem;
             }
 
-            &:disabled {
-              cursor: default;
-            }
-
             > svg {
               margin: 0 0.75rem;
+            }
+
+            &:disabled {
+              opacity: var(--opacity-disabled);
+              cursor: default;
             }
           }
 
@@ -210,6 +209,11 @@ export const CallToActionWrapper = styled.div`
             > button {
               cursor: default;
             }
+          }
+
+          &:disabled {
+            opacity: var(--opacity-disabled);
+            cursor: default;
           }
         }
       }

--- a/packages/app/src/library/SideMenu/Main.tsx
+++ b/packages/app/src/library/SideMenu/Main.tsx
@@ -9,6 +9,7 @@ import { useBalances } from 'contexts/Balances'
 import { useBonded } from 'contexts/Bonded'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useNetwork } from 'contexts/Network'
+import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useSetup } from 'contexts/Setup'
 import type { SetupContextInterface } from 'contexts/Setup/types'
 import { useStaking } from 'contexts/Staking'
@@ -26,12 +27,13 @@ export const Main = () => {
   const { t, i18n } = useTranslation('base')
   const { syncing } = useSyncing()
   const { pathname } = useLocation()
+  const { inPool } = useActivePool()
   const { networkData } = useNetwork()
+  const { getNominations } = useBalances()
   const { getBondedAccount } = useBonded()
   const { accounts } = useImportedAccounts()
   const { formatWithPrefs } = useValidators()
   const { activeAccount } = useActiveAccounts()
-  const { getPoolMembership, getNominations } = useBalances()
   const {
     getPoolSetupPercent,
     getNominatorSetupPercent,
@@ -39,7 +41,6 @@ export const Main = () => {
   const { sideMenuMinimised }: UIContextInterface = useUi()
   const { inSetup: inNominatorSetup, addressDifferentToStash } = useStaking()
 
-  const membership = getPoolMembership(activeAccount)
   const controller = getBondedAccount(activeAccount)
   const controllerDifferentToStash = addressDifferentToStash(controller)
 
@@ -99,9 +100,8 @@ export const Main = () => {
 
       if (uri === `${import.meta.env.BASE_URL}pools`) {
         // configure Pools action
-        const inPool = membership
 
-        if (inPool) {
+        if (inPool()) {
           pages[i].action = {
             type: 'text',
             status: 'success',
@@ -122,7 +122,7 @@ export const Main = () => {
     accounts,
     controllerDifferentToStash,
     syncing,
-    membership,
+    inPool(),
     inNominatorSetup(),
     getNominatorSetupPercent(activeAccount),
     getPoolSetupPercent(activeAccount),

--- a/packages/app/src/library/StatusLabel/index.tsx
+++ b/packages/app/src/library/StatusLabel/index.tsx
@@ -3,10 +3,9 @@
 
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { useActiveAccounts } from 'contexts/ActiveAccounts'
-import { useBalances } from 'contexts/Balances'
 import { useHelp } from 'contexts/Help'
 import { usePlugins } from 'contexts/Plugins'
+import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useStaking } from 'contexts/Staking'
 import { useSyncing } from 'hooks/useSyncing'
 import { ButtonHelp } from 'ui-buttons'
@@ -25,13 +24,11 @@ export const StatusLabel = ({
   const { syncing } = useSyncing()
   const { plugins } = usePlugins()
   const { inSetup } = useStaking()
-  const { getPoolMembership } = useBalances()
-  const { activeAccount } = useActiveAccounts()
-  const membership = getPoolMembership(activeAccount)
+  const { inPool } = useActivePool()
 
   // syncing or not staking
   if (status === 'sync_or_setup') {
-    if (syncing || !inSetup() || membership !== null) {
+    if (syncing || !inSetup() || inPool()) {
       return null
     }
   }

--- a/packages/app/src/overlay/canvas/JoinPool/Overview/index.tsx
+++ b/packages/app/src/overlay/canvas/JoinPool/Overview/index.tsx
@@ -4,7 +4,7 @@
 import { JoinForm } from './JoinForm'
 
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
-import { useBalances } from 'contexts/Balances'
+import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useStaking } from 'contexts/Staking'
 import { GraphLayoutWrapper } from '../Wrappers'
 import type { OverviewSectionProps } from '../types'
@@ -14,8 +14,8 @@ import { Roles } from './Roles'
 import { Stats } from './Stats'
 
 export const Overview = (props: OverviewSectionProps) => {
-  const { isNominating } = useStaking()
-  const { getPoolMembership } = useBalances()
+  const { inSetup } = useStaking()
+  const { inPool } = useActivePool()
   const { activeAccount } = useActiveAccounts()
 
   const {
@@ -23,10 +23,7 @@ export const Overview = (props: OverviewSectionProps) => {
   } = props
 
   const showJoinForm =
-    activeAccount !== null &&
-    state === 'Open' &&
-    getPoolMembership(activeAccount) === null &&
-    !isNominating()
+    activeAccount !== null && state === 'Open' && !inPool() && !inSetup()
 
   return (
     <>

--- a/packages/app/src/overlay/canvas/JoinPool/Overview/index.tsx
+++ b/packages/app/src/overlay/canvas/JoinPool/Overview/index.tsx
@@ -5,6 +5,7 @@ import { JoinForm } from './JoinForm'
 
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useBalances } from 'contexts/Balances'
+import { useStaking } from 'contexts/Staking'
 import { GraphLayoutWrapper } from '../Wrappers'
 import type { OverviewSectionProps } from '../types'
 import { Addresses } from './Addresses'
@@ -13,6 +14,7 @@ import { Roles } from './Roles'
 import { Stats } from './Stats'
 
 export const Overview = (props: OverviewSectionProps) => {
+  const { isNominating } = useStaking()
   const { getPoolMembership } = useBalances()
   const { activeAccount } = useActiveAccounts()
 
@@ -23,7 +25,8 @@ export const Overview = (props: OverviewSectionProps) => {
   const showJoinForm =
     activeAccount !== null &&
     state === 'Open' &&
-    getPoolMembership(activeAccount) === null
+    getPoolMembership(activeAccount) === null &&
+    !isNominating()
 
   return (
     <>

--- a/packages/app/src/pages/Nominate/Active/Status/NewNominator.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/NewNominator.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
+import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useOverlay } from 'kits/Overlay/Provider'
 import { CallToActionWrapper } from 'library/CallToAction'
 import { CallToActionLoader } from 'library/Loader/CallToAction'
@@ -17,12 +18,13 @@ export const NewNominator = ({ syncing }: NewNominatorProps) => {
   const { t } = useTranslation()
   const { isReady } = useApi()
   const navigate = useNavigate()
+  const { inPool } = useActivePool()
   const { openCanvas } = useOverlay().canvas
   const { activeAccount } = useActiveAccounts()
   const { isReadOnlyAccount } = useImportedAccounts()
 
   const nominateButtonDisabled =
-    !isReady || !activeAccount || isReadOnlyAccount(activeAccount)
+    !isReady || !activeAccount || isReadOnlyAccount(activeAccount) || inPool()
 
   return (
     <CallToActionWrapper>

--- a/packages/app/src/pages/Nominate/Active/Status/NominationStatus.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/NominationStatus.tsx
@@ -14,6 +14,7 @@ import { useUnstaking } from 'hooks/useUnstaking'
 import { useOverlay } from 'kits/Overlay/Provider'
 import { Stat } from 'library/Stat'
 import { useTranslation } from 'react-i18next'
+import { useActivePool } from '../../../../contexts/Pools/ActivePool'
 
 export const NominationStatus = ({
   showButtons = true,
@@ -23,19 +24,20 @@ export const NominationStatus = ({
   buttonType?: string
 }) => {
   const { t } = useTranslation('pages')
-  const { inSetup } = useStaking()
-  const { openModal } = useOverlay().modal
-  const { getBondedAccount } = useBonded()
-  const { syncing } = useSyncing(['initialization', 'era-stakers', 'balances'])
   const {
     isReady,
     networkMetrics: { fastUnstakeErasToCheckPerBlock },
   } = useApi()
+  const { inSetup } = useStaking()
+  const { inPool } = useActivePool()
+  const { openModal } = useOverlay().modal
+  const { getBondedAccount } = useBonded()
   const { activeAccount } = useActiveAccounts()
   const { checking, isExposed } = useFastUnstake()
   const { isReadOnlyAccount } = useImportedAccounts()
   const { getNominationStatus } = useNominationStatus()
   const { getFastUnstakeText, isUnstaking } = useUnstaking()
+  const { syncing } = useSyncing(['initialization', 'era-stakers', 'balances'])
 
   const fastUnstakeText = getFastUnstakeText()
   const controller = getBondedAccount(activeAccount)
@@ -65,7 +67,7 @@ export const NominationStatus = ({
     <Stat
       label={t('nominate.status')}
       helpKey="Nomination Status"
-      stat={nominationStatus.message}
+      stat={inPool() ? t('nominate.alreadyInPool') : nominationStatus.message}
       buttons={
         !showButtons || syncing
           ? []

--- a/packages/app/src/pages/Overview/Payouts/index.tsx
+++ b/packages/app/src/pages/Overview/Payouts/index.tsx
@@ -5,10 +5,9 @@ import { useSize } from '@w3ux/hooks'
 import { Odometer } from '@w3ux/react-odometer'
 import { minDecimalPlaces } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { useActiveAccounts } from 'contexts/ActiveAccounts'
-import { useBalances } from 'contexts/Balances'
 import { useNetwork } from 'contexts/Network'
 import { usePlugins } from 'contexts/Plugins'
+import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useStaking } from 'contexts/Staking'
 import { useUi } from 'contexts/UI'
 import { formatDistance, fromUnixTime, getUnixTime } from 'date-fns'
@@ -36,14 +35,10 @@ export const Payouts = () => {
   const { inSetup } = useStaking()
   const { syncing } = useSyncing()
   const { containerRefs } = useUi()
+  const { inPool } = useActivePool()
   const { pluginEnabled } = usePlugins()
-  const { getPoolMembership } = useBalances()
-  const { activeAccount } = useActiveAccounts()
 
-  const membership = getPoolMembership(activeAccount)
-  const nominating = !inSetup()
-  const inPool = membership !== null
-  const staking = nominating || inPool
+  const staking = !inSetup() || inPool
   const notStaking = !syncing && !staking
 
   const [lastReward, setLastReward] = useState<NominatorReward>()
@@ -121,8 +116,8 @@ export const Payouts = () => {
         >
           {staking && pluginEnabled('staking_api') ? (
             <ActiveGraph
-              nominating={nominating}
-              inPool={inPool}
+              nominating={!inSetup()}
+              inPool={inPool()}
               lineMarginTop="3rem"
               setLastReward={setLastReward}
             />

--- a/packages/app/src/pages/Overview/StakeStatus/Tips/index.tsx
+++ b/packages/app/src/pages/Overview/StakeStatus/Tips/index.tsx
@@ -8,7 +8,6 @@ import { TipsConfig } from 'config/tips'
 import { TipsThresholdMedium, TipsThresholdSmall } from 'consts'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
-import { useBalances } from 'contexts/Balances'
 import { useNetwork } from 'contexts/Network'
 import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useStaking } from 'contexts/Staking'
@@ -30,15 +29,14 @@ export const Tips = () => {
   const {
     stakingMetrics: { minNominatorBond },
   } = useApi()
+  const { inPool } = useActivePool()
   const { isOwner } = useActivePool()
   const { isNominating } = useStaking()
-  const { getPoolMembership } = useBalances()
   const { activeAccount } = useActiveAccounts()
   const { fillVariables } = useFillVariables()
   const { syncing } = useSyncing(['initialization'])
   const { feeReserve, getTransferOptions } = useTransferOptions()
 
-  const membership = getPoolMembership(activeAccount)
   const transferOptions = getTransferOptions(activeAccount)
 
   // multiple tips per row is currently turned off.
@@ -101,7 +99,7 @@ export const Tips = () => {
   const segments: AnyJson = []
   if (!activeAccount) {
     segments.push(1)
-  } else if (!isNominating() && !membership) {
+  } else if (!isNominating() && !inPool()) {
     if (
       transferOptions.freeBalance
         .minus(feeReserve)
@@ -116,7 +114,7 @@ export const Tips = () => {
     if (isNominating()) {
       segments.push(5)
     }
-    if (membership) {
+    if (inPool()) {
       if (!isOwner()) {
         segments.push(6)
       } else {

--- a/packages/app/src/pages/Overview/StakeStatus/index.tsx
+++ b/packages/app/src/pages/Overview/StakeStatus/index.tsx
@@ -14,7 +14,7 @@ import { StatusWrapper } from './Wrappers'
 export const StakeStatus = () => {
   const { plugins } = usePlugins()
   const { inPool } = useActivePool()
-  const { isNominating } = useStaking()
+  const { inSetup } = useStaking()
   const showTips = plugins.includes('tips')
 
   return (
@@ -34,7 +34,7 @@ export const StakeStatus = () => {
           <section
             style={{
               transition: 'opacity 0.2s',
-              opacity: isNominating() ? 'var(--opacity-disabled)' : 1,
+              opacity: !inSetup() ? 'var(--opacity-disabled)' : 1,
             }}
           >
             <MembershipStatus showButtons={false} />

--- a/packages/app/src/pages/Overview/StakeStatus/index.tsx
+++ b/packages/app/src/pages/Overview/StakeStatus/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { usePlugins } from 'contexts/Plugins'
+import { useStaking } from 'contexts/Staking'
 import { CardWrapper } from 'library/Card/Wrappers'
 import { NominationStatus } from 'pages/Nominate/Active/Status/NominationStatus'
 import { MembershipStatus } from 'pages/Pools/Status/MembershipStatus'
@@ -11,6 +12,7 @@ import { StatusWrapper } from './Wrappers'
 
 export const StakeStatus = () => {
   const { plugins } = usePlugins()
+  const { isNominating } = useStaking()
   const showTips = plugins.includes('tips')
 
   return (
@@ -22,7 +24,9 @@ export const StakeStatus = () => {
           </section>
         </RowSection>
         <RowSection hLast vLast>
-          <section>
+          <section
+            style={{ opacity: isNominating() ? 'var(--opacity-disabled)' : 1 }}
+          >
             <MembershipStatus showButtons={false} />
           </section>
         </RowSection>

--- a/packages/app/src/pages/Overview/StakeStatus/index.tsx
+++ b/packages/app/src/pages/Overview/StakeStatus/index.tsx
@@ -15,31 +15,33 @@ export const StakeStatus = () => {
   const { plugins } = usePlugins()
   const { inPool } = useActivePool()
   const { inSetup } = useStaking()
+
   const showTips = plugins.includes('tips')
+  const notStaking = !inPool() && inSetup()
+  const showNominate = notStaking || !inSetup()
+  const showMembership = notStaking || inPool()
 
   return (
     <CardWrapper style={{ padding: 0 }}>
       <StatusWrapper $borderBottom={showTips}>
-        <RowSection secondary>
-          <section
-            style={{
-              transition: 'opacity 0.2s',
-              opacity: inPool() ? 'var(--opacity-disabled)' : 1,
-            }}
+        {showNominate && (
+          <RowSection secondary={showMembership} standalone={!showMembership}>
+            <section>
+              <NominationStatus showButtons={false} />
+            </section>
+          </RowSection>
+        )}
+        {showMembership && (
+          <RowSection
+            hLast={showNominate}
+            vLast={showNominate}
+            standalone={!showNominate}
           >
-            <NominationStatus showButtons={false} />
-          </section>
-        </RowSection>
-        <RowSection hLast vLast>
-          <section
-            style={{
-              transition: 'opacity 0.2s',
-              opacity: !inSetup() ? 'var(--opacity-disabled)' : 1,
-            }}
-          >
-            <MembershipStatus showButtons={false} />
-          </section>
-        </RowSection>
+            <section>
+              <MembershipStatus showButtons={false} />
+            </section>
+          </RowSection>
+        )}
       </StatusWrapper>
 
       {showTips ? <Tips /> : null}

--- a/packages/app/src/pages/Overview/StakeStatus/index.tsx
+++ b/packages/app/src/pages/Overview/StakeStatus/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { usePlugins } from 'contexts/Plugins'
+import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useStaking } from 'contexts/Staking'
 import { CardWrapper } from 'library/Card/Wrappers'
 import { NominationStatus } from 'pages/Nominate/Active/Status/NominationStatus'
@@ -12,6 +13,7 @@ import { StatusWrapper } from './Wrappers'
 
 export const StakeStatus = () => {
   const { plugins } = usePlugins()
+  const { inPool } = useActivePool()
   const { isNominating } = useStaking()
   const showTips = plugins.includes('tips')
 
@@ -19,13 +21,21 @@ export const StakeStatus = () => {
     <CardWrapper style={{ padding: 0 }}>
       <StatusWrapper $borderBottom={showTips}>
         <RowSection secondary>
-          <section>
+          <section
+            style={{
+              transition: 'opacity 0.2s',
+              opacity: inPool() ? 'var(--opacity-disabled)' : 1,
+            }}
+          >
             <NominationStatus showButtons={false} />
           </section>
         </RowSection>
         <RowSection hLast vLast>
           <section
-            style={{ opacity: isNominating() ? 'var(--opacity-disabled)' : 1 }}
+            style={{
+              transition: 'opacity 0.2s',
+              opacity: isNominating() ? 'var(--opacity-disabled)' : 1,
+            }}
           >
             <MembershipStatus showButtons={false} />
           </section>

--- a/packages/app/src/pages/Payouts/index.tsx
+++ b/packages/app/src/pages/Payouts/index.tsx
@@ -3,10 +3,9 @@
 
 import { useSize } from '@w3ux/hooks'
 import type { AnyApi, PageProps } from 'common-types'
-import { useActiveAccounts } from 'contexts/ActiveAccounts'
-import { useBalances } from 'contexts/Balances'
 import { useHelp } from 'contexts/Help'
 import { usePlugins } from 'contexts/Plugins'
+import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useStaking } from 'contexts/Staking'
 import { useUi } from 'contexts/UI'
 import { useSyncing } from 'hooks/useSyncing'
@@ -35,13 +34,10 @@ export const Payouts = ({ page: { key } }: PageProps) => {
   const { inSetup } = useStaking()
   const { syncing } = useSyncing()
   const { containerRefs } = useUi()
+  const { inPool } = useActivePool()
   const { pluginEnabled } = usePlugins()
-  const { getPoolMembership } = useBalances()
-  const { activeAccount } = useActiveAccounts()
 
-  const membership = getPoolMembership(activeAccount)
   const nominating = !inSetup()
-  const inPool = membership !== null
   const staking = nominating || inPool
   const notStaking = !syncing && !staking
 
@@ -124,7 +120,7 @@ export const Payouts = ({ page: { key } }: PageProps) => {
               {staking && pluginEnabled('staking_api') ? (
                 <ActiveGraph
                   nominating={nominating}
-                  inPool={inPool}
+                  inPool={inPool()}
                   setPayoutLists={setPayoutLists}
                 />
               ) : (

--- a/packages/app/src/pages/Pools/Status/MembershipStatus.tsx
+++ b/packages/app/src/pages/Pools/Status/MembershipStatus.tsx
@@ -8,6 +8,7 @@ import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useBondedPools } from 'contexts/Pools/BondedPools'
 import { determinePoolDisplay } from 'contexts/Pools/util'
+import { useStaking } from 'contexts/Staking'
 import { useTransferOptions } from 'contexts/TransferOptions'
 import { useOverlay } from 'kits/Overlay/Provider'
 import { Stat } from 'library/Stat'
@@ -21,10 +22,11 @@ export const MembershipStatus = ({
 }: MembershipStatusProps) => {
   const { t } = useTranslation('pages')
   const { isReady } = useApi()
+  const { inSetup } = useStaking()
+  const { label } = useStatusButtons()
   const { openModal } = useOverlay().modal
   const { poolsMetaData } = useBondedPools()
   const { activeAccount } = useActiveAccounts()
-  const { label } = useStatusButtons()
   const { isReadOnlyAccount } = useImportedAccounts()
   const { getTransferOptions } = useTransferOptions()
   const { activePool, isOwner, isBouncer, isMember } = useActivePool()
@@ -81,7 +83,7 @@ export const MembershipStatus = ({
     <Stat
       label={t('pools.poolMembership')}
       helpKey="Pool Membership"
-      stat={t('pools.notInPool')}
+      stat={!inSetup() ? t('pools.alreadyNominating') : t('pools.notInPool')}
       buttonType={buttonType}
     />
   )

--- a/packages/app/src/pages/Pools/Status/NewMember.tsx
+++ b/packages/app/src/pages/Pools/Status/NewMember.tsx
@@ -18,7 +18,7 @@ import { useStatusButtons } from './useStatusButtons'
 
 export const NewMember = ({ syncing }: NewMemberProps) => {
   const { t } = useTranslation()
-  const { isNominating } = useStaking()
+  const { inSetup } = useStaking()
   const { poolsForJoin } = useJoinPools()
   const { setActiveTab } = usePoolsTabs()
   const { openCanvas } = useOverlay().canvas
@@ -30,11 +30,11 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
   const poolJoinPerformanceTask = getPoolPerformanceTask('pool_join')
 
   // Alias for create button disabled state
-  const createDisabled = getCreateDisabled() || isNominating()
+  const createDisabled = getCreateDisabled() || !inSetup()
 
   // Disable opening the canvas if data is not ready.
   const joinButtonDisabled =
-    getJoinDisabled() || !poolsForJoin.length || isNominating()
+    getJoinDisabled() || !poolsForJoin.length || !inSetup()
 
   return (
     <CallToActionWrapper>

--- a/packages/app/src/pages/Pools/Status/NewMember.tsx
+++ b/packages/app/src/pages/Pools/Status/NewMember.tsx
@@ -5,6 +5,7 @@ import { faUserPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useJoinPools } from 'contexts/Pools/JoinPools'
 import { usePoolPerformance } from 'contexts/Pools/PoolPerformance'
+import { useStaking } from 'contexts/Staking'
 import { useOverlay } from 'kits/Overlay/Provider'
 import { CallToActionWrapper } from 'library/CallToAction'
 import { CallToActionLoader } from 'library/Loader/CallToAction'
@@ -17,6 +18,7 @@ import { useStatusButtons } from './useStatusButtons'
 
 export const NewMember = ({ syncing }: NewMemberProps) => {
   const { t } = useTranslation()
+  const { isNominating } = useStaking()
   const { poolsForJoin } = useJoinPools()
   const { setActiveTab } = usePoolsTabs()
   const { openCanvas } = useOverlay().canvas
@@ -27,11 +29,12 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
   // Get the pool performance task to determine if performance data is ready.
   const poolJoinPerformanceTask = getPoolPerformanceTask('pool_join')
 
-  // Alias for create button disabled state.
-  const createDisabled = getCreateDisabled()
+  // Alias for create button disabled state
+  const createDisabled = getCreateDisabled() || isNominating()
 
   // Disable opening the canvas if data is not ready.
-  const joinButtonDisabled = getJoinDisabled() || !poolsForJoin.length
+  const joinButtonDisabled =
+    getJoinDisabled() || !poolsForJoin.length || isNominating()
 
   return (
     <CallToActionWrapper>
@@ -43,7 +46,7 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
             <section className="fixedWidth">
               <div className="buttons">
                 <div
-                  className={`button primary standalone${getJoinDisabled() ? ` disabled` : ``}${poolJoinPerformanceTask.status === 'synced' ? ` pulse` : ``}`}
+                  className={`button primary standalone${joinButtonDisabled ? ` disabled` : ``}${poolJoinPerformanceTask.status === 'synced' ? ` pulse` : ``}`}
                 >
                   <button
                     onClick={() => {

--- a/packages/app/src/pages/Pools/Status/index.tsx
+++ b/packages/app/src/pages/Pools/Status/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
-import { useBalances } from 'contexts/Balances'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useSyncing } from 'hooks/useSyncing'
@@ -15,31 +14,29 @@ import { RewardsStatus } from './RewardsStatus'
 import type { StatusProps } from './types'
 
 export const Status = ({ height }: StatusProps) => {
-  const { activePool } = useActivePool()
-  const { getPoolMembership } = useBalances()
   const { poolMembersipSyncing } = useSyncing()
   const { activeAccount } = useActiveAccounts()
+  const { activePool, inPool } = useActivePool()
   const { isReadOnlyAccount } = useImportedAccounts()
 
-  const membership = getPoolMembership(activeAccount)
   const syncing = poolMembersipSyncing()
 
   return (
     <CardWrapper
       height={height}
-      className={!syncing && !activePool && !membership ? 'prompt' : undefined}
+      className={!syncing && !activePool && !inPool() ? 'prompt' : undefined}
     >
       <MembershipStatus />
       <Separator />
-      <RewardsStatus dimmed={membership === null} />
+      <RewardsStatus dimmed={inPool() === null} />
       {!syncing ? (
-        activePool && !!membership ? (
+        activePool && inPool() ? (
           <>
             <Separator />
             <PoolStatus />
           </>
         ) : (
-          membership === null &&
+          !inPool() &&
           !isReadOnlyAccount(activeAccount) && <NewMember syncing={syncing} />
         )
       ) : (

--- a/packages/locales/src/resources/cn/pages.json
+++ b/packages/locales/src/resources/cn/pages.json
@@ -1,8 +1,6 @@
 {
   "pages": {
-    "common": {
-      "stakingApiDisabled": "Staking API己断开"
-    },
+    "common": { "stakingApiDisabled": "Staking API己断开" },
     "community": {
       "bio": "简介",
       "connecting": "连接中",
@@ -29,6 +27,7 @@
     "nominate": {
       "activeNominations": "活跃提名人",
       "addressCopied": "地址已复制到剪贴板",
+      "alreadyInPool": "无法提名：已在候选池中",
       "automaticallyBonded": "将自动质押收益到现有的质押余额中",
       "back": "返回",
       "bond": "质押",
@@ -143,6 +142,7 @@
       "addressCopied": "地址已复制到剪贴板",
       "addressInvalid": "地址无效",
       "allPools": "所有提名池",
+      "alreadyNominating": "无法加入池：已提名",
       "assigned": "己分配",
       "assignedToAnyAccount": " 您的<b>主理人</b>、<b>提名人</b>和<b>守护人</b>角色可以分配给任何帐户。",
       "availableToClaim": "成员可申领的奖励{{unit}}金额",

--- a/packages/locales/src/resources/cn/pages.json
+++ b/packages/locales/src/resources/cn/pages.json
@@ -27,7 +27,7 @@
     "nominate": {
       "activeNominations": "活跃提名人",
       "addressCopied": "地址已复制到剪贴板",
-      "alreadyInPool": "无法提名：已在候选池中",
+      "alreadyInPool": "无需提名：已在提名池中",
       "automaticallyBonded": "将自动质押收益到现有的质押余额中",
       "back": "返回",
       "bond": "质押",

--- a/packages/locales/src/resources/en/pages.json
+++ b/packages/locales/src/resources/en/pages.json
@@ -1,8 +1,6 @@
 {
   "pages": {
-    "common": {
-      "stakingApiDisabled": "Staking API Disabled"
-    },
+    "common": { "stakingApiDisabled": "Staking API Disabled" },
     "community": {
       "bio": "Bio",
       "connecting": "Connecting",
@@ -30,6 +28,7 @@
     "nominate": {
       "activeNominations": "Active Nominations",
       "addressCopied": "Address Copied to Clipboard",
+      "alreadyInPool": "Cannot Nominate: Already in Pool",
       "automaticallyBonded": "Automatically bond payouts to your existing staked balance.",
       "back": "Back",
       "bond": "Bond",
@@ -145,6 +144,7 @@
       "addressCopied": "Address Copied to Clipboard",
       "addressInvalid": "Address Invalid",
       "allPools": "All Pools",
+      "alreadyNominating": "Cannot Join Pool: Already Nominating",
       "assigned": "Assigned",
       "assignedToAnyAccount": " Your <b>Root</b>, <b>Nominator</b> and <b>Bouncer</b> roles can be assigned to any account.",
       "availableToClaim": "The outstanding amount of {{unit}} available to claim by pool members.",

--- a/packages/ui-buttons/tsconfig.json
+++ b/packages/ui-buttons/tsconfig.json
@@ -16,5 +16,5 @@
     "jsx": "react-jsx",
     "noEmit": true
   },
-  "include": ["src"]
+  "include": ["src", "../../env.d.ts"]
 }

--- a/packages/ui-structure/src/RowSection/index.module.scss
+++ b/packages/ui-structure/src/RowSection/index.module.scss
@@ -62,12 +62,17 @@
   }
 }
 
+.rowNoHPadding {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
 .rowSecondaryWrapperLast {
   @media (min-width: $page-width-medium-threshold) {
     padding-right: 0.75rem;
   }
 }
 
-.rowSSectionVLast {
+.rowSectionVLast {
   order: 1;
 }

--- a/packages/ui-structure/src/RowSection/index.tsx
+++ b/packages/ui-structure/src/RowSection/index.tsx
@@ -15,6 +15,7 @@ export const RowSection = ({
   vLast,
   hLast,
   secondary,
+  standalone,
 }: RowSectionProps) => {
   const mainClass = secondary
     ? classes.rowSecondaryWrapper
@@ -31,12 +32,13 @@ export const RowSection = ({
       : classes.rowPrimaryWrapperLast
   }
 
-  const buttonClasses = classNames(mainClass, hClass, {
-    [classes.rowSSectionVLast]: vLast,
+  const rowClasses = classNames(mainClass, hClass, {
+    [classes.rowSectionVLast]: vLast,
+    [classes.rowNoHPadding]: standalone,
   })
 
   return (
-    <div className={buttonClasses} style={style}>
+    <div className={rowClasses} style={style}>
       {children}
     </div>
   )

--- a/packages/ui-structure/src/RowSection/types.ts
+++ b/packages/ui-structure/src/RowSection/types.ts
@@ -10,4 +10,6 @@ export type RowSectionProps = ComponentBase & {
   hLast?: boolean
   // `true` means the secondary element and  false means the primary one.
   secondary?: boolean
+  // `true` means row is hostiing only a singular element.
+  standalone?: boolean
 }

--- a/packages/ui-structure/tsconfig.json
+++ b/packages/ui-structure/tsconfig.json
@@ -16,5 +16,5 @@
     "jsx": "react-jsx",
     "noEmit": true
   },
-  "include": ["src"]
+  "include": ["src", "../../env.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "strictPropertyInitialization": false,
     "noUnusedLocals": true
   },
-  "include": ["packages/**/*", "env.d.ts", "eslint.config.js"],
+  "include": ["packages/**/*", "**/*.d.ts", "eslint.config.js"],
   "exclude": ["**/*/node_modules", "**/*/dist", "**/*/lottie"]
 }


### PR DESCRIPTION
Disables dual staking: 
- If in a pool, app will disable nominator setup for the active account.
- If a nominator, app will disable pool joining and creation for the active account.
- Stake Status (top of overview) has been amended to not display the inactive type of staking when the other is active.
- Added nominator / pool status messages when already staking via the other method.