### PR TITLE
feat: Use pool points for unbonding / leaving pool

### DIFF
--- a/packages/app/src/api/runtimeApi/poolBalanceToPoints.ts
+++ b/packages/app/src/api/runtimeApi/poolBalanceToPoints.ts
@@ -1,0 +1,31 @@
+// Copyright 2024 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { Base } from 'api/base'
+import type { ChainId } from 'common-types'
+
+export class PoolBalanceToPoints extends Base {
+  #poolId: number
+  #balance: bigint
+
+  constructor(network: ChainId, poolId: number, balance: bigint) {
+    super(network)
+    this.#poolId = poolId
+    this.#balance = balance
+  }
+
+  async fetch() {
+    try {
+      const result =
+        await this.unsafeApi.apis.NominationPoolsApi.balance_to_points(
+          this.#poolId,
+          this.#balance,
+          { at: 'best' }
+        )
+      return result
+    } catch (e) {
+      // Silently fail.
+    }
+    return undefined
+  }
+}

--- a/packages/app/src/api/tx/poolUnbond.ts
+++ b/packages/app/src/api/tx/poolUnbond.ts
@@ -6,12 +6,12 @@ import type { ChainId } from 'common-types'
 
 export class PoolUnbond extends Base {
   #who: string
-  #bond: bigint
+  #points: bigint
 
-  constructor(network: ChainId, who: string, bond: bigint) {
+  constructor(network: ChainId, who: string, points: bigint) {
     super(network)
     this.#who = who
-    this.#bond = bond
+    this.#points = points
   }
 
   tx() {
@@ -21,7 +21,7 @@ export class PoolUnbond extends Base {
           type: 'Id',
           value: this.#who,
         },
-        unbonding_points: this.#bond,
+        unbonding_points: this.#points,
       })
     } catch (e) {
       return null

--- a/packages/app/src/controllers/Subscan/index.ts
+++ b/packages/app/src/controllers/Subscan/index.ts
@@ -106,7 +106,6 @@ export class Subscan {
         poolId: entry.pool_id,
       }))
       .reverse()
-      .splice(0, result.list.length - 1)
   }
 
   // Fetch a pool's era points from Subscan.

--- a/packages/app/src/overlay/canvas/PoolMembers/Lists/Member.tsx
+++ b/packages/app/src/overlay/canvas/PoolMembers/Lists/Member.tsx
@@ -56,15 +56,6 @@ export const Member = ({
 
   const menuItems: AnyJson[] = []
 
-  menuItems.push({
-    icon: <FontAwesomeIcon icon={faUnlockAlt} transform="shrink-3" />,
-    wrap: null,
-    title: `${t('pools.withdrawFunds', { ns: 'pages' })}`,
-    cb: () => {
-      openPromptWith(<UnbondMember who={who} member={member} />)
-    },
-  })
-
   if (member && (canUnbondBlocked || canUnbondDestroying)) {
     const { points, unbondingEras } = member
 
@@ -72,7 +63,7 @@ export const Member = ({
       menuItems.push({
         icon: <FontAwesomeIcon icon={faUnlockAlt} transform="shrink-3" />,
         wrap: null,
-        title: `${t('pools.unbondFunds', { ns: 'pages' })}`,
+        title: `${t('pools.withdrawFunds', { ns: 'pages' })}`,
         cb: () => {
           openPromptWith(<UnbondMember who={who} member={member} />)
         },

--- a/packages/app/src/overlay/canvas/PoolMembers/Lists/Member.tsx
+++ b/packages/app/src/overlay/canvas/PoolMembers/Lists/Member.tsx
@@ -63,7 +63,7 @@ export const Member = ({
       menuItems.push({
         icon: <FontAwesomeIcon icon={faUnlockAlt} transform="shrink-3" />,
         wrap: null,
-        title: `${t('pools.withdrawFunds', { ns: 'pages' })}`,
+        title: `${t('pools.unbondFunds', { ns: 'pages' })}`,
         cb: () => {
           openPromptWith(<UnbondMember who={who} member={member} />)
         },

--- a/packages/app/src/overlay/modals/ManagePool/Forms/LeavePool/index.tsx
+++ b/packages/app/src/overlay/modals/ManagePool/Forms/LeavePool/index.tsx
@@ -58,18 +58,13 @@ export const LeavePool = ({
     erasToSeconds(bondDuration),
     true
   )
-
+  const freeToUnbond = planckToUnitBn(activeBn, units)
   const pendingRewardsUnit = planckToUnit(pendingRewards, units)
 
-  // Convert BigNumber values to number
-  const freeToUnbond = planckToUnitBn(activeBn, units)
+  const [paramsValid, setParamsValid] = useState<boolean>(false)
 
-  // Bond valid
-  const [pointsValid, setPointsValid] = useState<boolean>(false)
-
-  // Update bond value on task change
   useEffect(() => {
-    setPointsValid(BigInt(membership?.points || 0) > 0 && !!activePool?.id)
+    setParamsValid(BigInt(membership?.points || 0) > 0 && !!activePool?.id)
   }, [freeToUnbond.toString()])
 
   const getTx = () => {
@@ -84,7 +79,7 @@ export const LeavePool = ({
   const submitExtrinsic = useSubmitExtrinsic({
     tx: getTx(),
     from: activeAccount,
-    shouldSubmit: pointsValid,
+    shouldSubmit: paramsValid,
     callbackSubmit: () => {
       setModalStatus('closing')
     },
@@ -112,7 +107,9 @@ export const LeavePool = ({
             ))}
           </ModalWarnings>
         ) : null}
-        <ActionItem text={`${t('unbond')} ${freeToUnbond} ${unit}`} />
+        <ActionItem
+          text={`${t('unbond')} ${freeToUnbond.toString()} ${unit}`}
+        />
         <StaticNote
           value={bondDurationFormatted}
           tKey="onceUnbonding"
@@ -121,7 +118,7 @@ export const LeavePool = ({
         />
       </ModalPadding>
       <SubmitTx
-        valid={pointsValid}
+        valid={paramsValid}
         buttons={[
           <ButtonSubmitInvert
             key="button_back"

--- a/packages/app/src/overlay/modals/ManagePool/Forms/LeavePool/index.tsx
+++ b/packages/app/src/overlay/modals/ManagePool/Forms/LeavePool/index.tsx
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons'
-import { planckToUnit, unitToPlanck } from '@w3ux/utils'
+import { planckToUnit } from '@w3ux/utils'
 import { PoolUnbond } from 'api/tx/poolUnbond'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
+import { useBalances } from 'contexts/Balances'
 import { useNetwork } from 'contexts/Network'
 import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useTransferOptions } from 'contexts/TransferOptions'
@@ -39,17 +40,18 @@ export const LeavePool = ({
     networkData: { units, unit },
   } = useNetwork()
   const { activePool } = useActivePool()
+  const { getPoolMembership } = useBalances()
   const { erasToSeconds } = useErasToTimeLeft()
+  const { setModalStatus } = useOverlay().modal
   const { activeAccount } = useActiveAccounts()
   const { getSignerWarnings } = useSignerWarnings()
   const { getTransferOptions } = useTransferOptions()
-  const { setModalStatus, setModalResize } = useOverlay().modal
 
   const allTransferOptions = getTransferOptions(activeAccount)
   const { active: activeBn } = allTransferOptions.pool
   const { bondDuration } = consts
   const pendingRewards = activePool?.pendingRewards || 0n
-
+  const membership = getPoolMembership(activeAccount)
   const bondDurationFormatted = timeleftAsString(
     t,
     getUnixTime(new Date()) + 1,
@@ -59,46 +61,30 @@ export const LeavePool = ({
 
   const pendingRewardsUnit = planckToUnit(pendingRewards, units)
 
-  // convert BigNumber values to number
+  // Convert BigNumber values to number
   const freeToUnbond = planckToUnitBn(activeBn, units)
 
-  // local bond value
-  const [bond, setBond] = useState<{ bond: string }>({
-    bond: freeToUnbond.toString(),
-  })
+  // Bond valid
+  const [pointsValid, setPointsValid] = useState<boolean>(false)
 
-  // bond valid
-  const [bondValid, setBondValid] = useState<boolean>(false)
-
-  // unbond all validation
-  const isValid = (() => freeToUnbond.isGreaterThan(0))()
-
-  // update bond value on task change
+  // Update bond value on task change
   useEffect(() => {
-    setBond({ bond: freeToUnbond.toString() })
-    setBondValid(isValid)
-  }, [freeToUnbond.toString(), isValid])
-
-  // modal resize on form update
-  useEffect(() => setModalResize(), [bond])
+    setPointsValid(BigInt(membership?.points || 0) > 0 && !!activePool?.id)
+  }, [freeToUnbond.toString()])
 
   const getTx = () => {
     let tx = null
-    if (!activeAccount) {
+    if (!activeAccount || !membership) {
       return tx
     }
-    tx = new PoolUnbond(
-      network,
-      activeAccount,
-      unitToPlanck(!bondValid ? 0 : bond.bond, units)
-    ).tx()
+    tx = new PoolUnbond(network, activeAccount, BigInt(membership.points)).tx()
     return tx
   }
 
   const submitExtrinsic = useSubmitExtrinsic({
     tx: getTx(),
     from: activeAccount,
-    shouldSubmit: bondValid,
+    shouldSubmit: pointsValid,
     callbackSubmit: () => {
       setModalStatus('closing')
     },
@@ -135,7 +121,7 @@ export const LeavePool = ({
         />
       </ModalPadding>
       <SubmitTx
-        valid={bondValid}
+        valid={pointsValid}
         buttons={[
           <ButtonSubmitInvert
             key="button_back"


### PR DESCRIPTION
- Uses the `balanceToPoints` runtime API when unbonding.
- Refers to active pool member points when leaving a pool or unbonding for a member.
- Fixes a Subscan issue where last member was getting cut from pool member results.