### PR TITLE
feat: Tx subscriptions to `TxSubmission`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ staking.polkadot.cloud/#/overview?n=kusama&l=cn
 - 29/06/2023: [[Video] Polkadot Decoded 2023: The Next Step of the Polkadot UX Journey](https://www.youtube.com/watch?v=s78SZZ_ZA64)
 - 30/06/2022: [[Video] Polkadot Decoded 2022: Polkadot Staking Dashboard Demo](https://youtu.be/H1WGu6mf1Ls)
 
-
 ## Repository Transfer History
 
 **17/06/2024:** Moved from `paritytech/polkadot-staking-dashboard`.
-

--- a/packages/app/src/api/txSubmission.ts
+++ b/packages/app/src/api/txSubmission.ts
@@ -68,7 +68,6 @@ export class TxSubmission {
     tx: any,
     signer: PolkadotSigner,
     nonce: number,
-
     {
       onReady,
       onInBlock,

--- a/packages/app/src/api/txSubmission.ts
+++ b/packages/app/src/api/txSubmission.ts
@@ -1,32 +1,32 @@
 // Copyright 2024 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { PolkadotSigner } from 'polkadot-api'
+import type { Subscription } from 'rxjs'
 import type { MaybeAddress } from 'types'
 import type { TxSubmissionItem } from './types'
 
 export class TxSubmission {
+  // Transaction items
   static uids: TxSubmissionItem[] = []
+
+  // Transaction subscriptions
+  static subs: Record<number, Subscription> = {}
 
   static getUid(id: number) {
     return this.uids.find((item) => item.uid === id)
   }
 
   static addUid({ from, tag }: { from: MaybeAddress; tag?: string }) {
-    // If tag already exists, delete the entry.
+    // Ensure uid is unique
+    const newUid = this.uids.length + 1
+    // If tag already exists, delete the entry
     if (tag) {
       this.uids = this.uids.filter((item) => item.tag !== tag)
     }
-    const newUid = this.uids.length + 1
     this.uids.push({ uid: newUid, processing: false, from, fee: 0n, tag })
     this.dispatchEvent()
     return newUid
-  }
-
-  static updateFee(uid: number, fee: bigint) {
-    this.uids = this.uids.map((item) =>
-      item.uid === uid ? { ...item, fee } : item
-    )
-    this.dispatchEvent()
   }
 
   static removeUid(id: number) {
@@ -39,6 +39,65 @@ export class TxSubmission {
       item.uid === id ? { ...item, processing: newProcessing } : item
     )
     this.dispatchEvent()
+  }
+
+  static updateFee(uid: number, fee: bigint) {
+    this.uids = this.uids.map((item) =>
+      item.uid === uid ? { ...item, fee } : item
+    )
+    this.dispatchEvent()
+  }
+
+  static async addSub(
+    uid: number,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tx: any,
+    signer: PolkadotSigner,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { onReady, onInBlock, onFinalized, onFailed, onError }: any
+  ) {
+    try {
+      this.subs[uid] = tx.signSubmitAndWatch(signer).subscribe({
+        next: (result: { type: string }) => {
+          const eventType = result?.type
+
+          if (eventType === 'broadcasted') {
+            onReady()
+          }
+          if (eventType === 'txBestBlocksState') {
+            this.setUidProcessing(uid, false)
+            onInBlock()
+          }
+          if (eventType === 'finalized') {
+            onFinalized()
+            this.deleteTx(uid)
+          }
+        },
+        error: (err: Error) => {
+          onFailed(err)
+          this.deleteTx(uid)
+        },
+      })
+    } catch (e) {
+      onError('default')
+      this.deleteTx(uid)
+    }
+  }
+
+  static removeSub(uid: number) {
+    const sub = this.subs[uid]
+    if (sub) {
+      sub.unsubscribe()
+      this.subs = Object.fromEntries(
+        Object.entries(this.subs).filter(([key]) => Number(key) !== uid)
+      )
+    }
+  }
+
+  static deleteTx(uid: number) {
+    this.setUidProcessing(uid, false)
+    this.removeUid(uid)
+    this.removeSub(uid)
   }
 
   static dispatchEvent = () => {

--- a/packages/app/src/api/txSubmission.ts
+++ b/packages/app/src/api/txSubmission.ts
@@ -68,8 +68,20 @@ export class TxSubmission {
     tx: any,
     signer: PolkadotSigner,
     nonce: number,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    { onReady, onInBlock, onFinalized, onFailed, onError }: any
+
+    {
+      onReady,
+      onInBlock,
+      onFinalized,
+      onFailed,
+      onError,
+    }: {
+      onReady: () => void
+      onInBlock: () => void
+      onFinalized: () => void
+      onFailed: (err?: Error) => void
+      onError: (type?: string) => void
+    }
   ) {
     try {
       this.subs[uid] = tx.signSubmitAndWatch(signer, { nonce }).subscribe({

--- a/packages/app/src/api/txSubmission.ts
+++ b/packages/app/src/api/txSubmission.ts
@@ -26,7 +26,7 @@ export class TxSubmission {
     }
     this.uids.push({
       uid: newUid,
-      processing: false,
+      submitted: false,
       pending: false,
       from,
       fee: 0n,
@@ -41,9 +41,9 @@ export class TxSubmission {
     this.dispatchEvent()
   }
 
-  static setUidProcessing(id: number, newProcessing: boolean) {
+  static setUidSubmitted(id: number, newSubmitted: boolean) {
     this.uids = this.uids.map((item) =>
-      item.uid === id ? { ...item, processing: newProcessing } : item
+      item.uid === id ? { ...item, submitted: newSubmitted } : item
     )
     this.dispatchEvent()
   }
@@ -82,7 +82,7 @@ export class TxSubmission {
           }
           if (eventType === 'txBestBlocksState') {
             onInBlock()
-            this.setUidProcessing(uid, false)
+            this.setUidSubmitted(uid, false)
             this.setUidPending(uid, false)
           }
           if (eventType === 'finalized') {
@@ -112,7 +112,7 @@ export class TxSubmission {
   }
 
   static deleteTx(uid: number) {
-    this.setUidProcessing(uid, false)
+    this.setUidSubmitted(uid, false)
     this.setUidPending(uid, false)
     this.removeUid(uid)
     this.removeSub(uid)

--- a/packages/app/src/api/txSubmission.ts
+++ b/packages/app/src/api/txSubmission.ts
@@ -79,7 +79,7 @@ export class TxSubmission {
       onReady: () => void
       onInBlock: () => void
       onFinalized: () => void
-      onFailed: (err?: Error) => void
+      onFailed: (err: Error) => void
       onError: (type?: string) => void
     }
   ) {

--- a/packages/app/src/api/types.ts
+++ b/packages/app/src/api/types.ts
@@ -51,4 +51,5 @@ export type TxSubmissionItem = {
   fee: bigint
   from: MaybeAddress
   processing: boolean
+  pending: boolean
 }

--- a/packages/app/src/api/types.ts
+++ b/packages/app/src/api/types.ts
@@ -50,6 +50,6 @@ export type TxSubmissionItem = {
   tag?: string
   fee: bigint
   from: MaybeAddress
-  processing: boolean
+  submitted: boolean
   pending: boolean
 }

--- a/packages/app/src/contexts/Balances/types.ts
+++ b/packages/app/src/contexts/Balances/types.ts
@@ -32,9 +32,9 @@ export interface ActiveBalance {
 }
 
 export interface Balances {
-  nonce?: number
-  balance?: Balance
-  locks?: BalanceLock[]
+  nonce: number
+  balance: Balance
+  locks: BalanceLock[]
 }
 
 export interface BalanceLocks {

--- a/packages/app/src/contexts/TxMeta/index.tsx
+++ b/packages/app/src/contexts/TxMeta/index.tsx
@@ -16,7 +16,7 @@ export const TxMetaContext = createContext<TxMetaContextInterface>(
 export const useTxMeta = () => useContext(TxMetaContext)
 
 export const TxMetaProvider = ({ children }: { children: ReactNode }) => {
-  // Store uids of transactions, along with their processing status.
+  // Store uids of transactions, along with their status.
   const [uids, setUids] = useState<TxSubmissionItem[]>([])
 
   const handleNewUidStatus = (e: Event) => {

--- a/packages/app/src/hooks/useActiveBalances/index.tsx
+++ b/packages/app/src/hooks/useActiveBalances/index.tsx
@@ -33,14 +33,14 @@ export const useActiveBalances = ({
 }) => {
   const { network } = useNetwork()
 
-  // Ensure no account duplicates.
+  // Ensure no account duplicates
   const uniqueAccounts = [...new Set(accounts)]
 
-  // Store active account balances state. Requires ref for use in event listener callbacks.
+  // Store active account balances state. Requires ref for use in event listener callbacks
   const [activeBalances, setActiveBalances] = useState<ActiveBalancesState>({})
   const activeBalancesRef = useRef(activeBalances)
 
-  // Gets an active balance's balance.
+  // Gets an active balance's balance
   const getBalance = (address: MaybeAddress) => {
     if (address) {
       const maybeBalance = activeBalances[address]?.balances?.balance
@@ -51,7 +51,18 @@ export const useActiveBalances = ({
     return defaultBalance
   }
 
-  // Gets the largest lock balance, dictating the total amount of unavailable funds from locks.
+  // Gets an active balance's nonce
+  const getNonce = (address: MaybeAddress) => {
+    if (address) {
+      const maybeNonce = activeBalances[address]?.balances?.nonce
+      if (maybeNonce) {
+        return maybeNonce
+      }
+    }
+    return 0
+  }
+
+  // Gets the largest lock balance, dictating the total amount of unavailable funds from locks
   const getMaxLock = (locks: BalanceLock[]): BigNumber =>
     locks.reduce(
       (prev, current) =>
@@ -59,7 +70,7 @@ export const useActiveBalances = ({
       { amount: new BigNumber(0) }
     )?.amount || new BigNumber(0)
 
-  // Gets an active balance's locks.
+  // Gets an active balance's locks
   const getLocks = (address: MaybeAddress): BalanceLocks => {
     if (address) {
       const maybeLocks = activeBalances[address]?.balances?.locks
@@ -74,7 +85,7 @@ export const useActiveBalances = ({
     }
   }
 
-  // Gets a ledger for a stash address.
+  // Gets a ledger for a stash address
   const getLedger = (source: ActiveLedgerSource): Ledger => {
     if ('stash' in source) {
       const stash = source['stash']
@@ -93,7 +104,7 @@ export const useActiveBalances = ({
     return defaultLedger
   }
 
-  // Gets an active balance's payee.
+  // Gets an active balance's payee
   const getPayee = (address: MaybeAddress): PayeeConfig => {
     if (address) {
       const maybePayee = activeBalances[address]?.payee
@@ -104,7 +115,7 @@ export const useActiveBalances = ({
     return defaultPayee
   }
 
-  // Gets an active balance's pool membership.
+  // Gets an active balance's pool membership
   const getPoolMembership = (address: MaybeAddress): PoolMembership | null => {
     if (address) {
       const maybePoolMembership = activeBalances[address]?.poolMembership
@@ -115,7 +126,7 @@ export const useActiveBalances = ({
     return null
   }
 
-  // Gets the amount of balance reserved for existential deposit.
+  // Gets the amount of balance reserved for existential deposit
   const getEdReserved = (
     address: MaybeAddress,
     existentialDeposit: BigNumber
@@ -127,7 +138,7 @@ export const useActiveBalances = ({
     return new BigNumber(0)
   }
 
-  // Gets an active balance's nominations.
+  // Gets an active balance's nominations
   const getNominations = (address: MaybeAddress): Targets => {
     if (address) {
       const maybeNominations =
@@ -139,12 +150,12 @@ export const useActiveBalances = ({
     return []
   }
 
-  // Handle new account balance event being reported from `Balances`.
+  // Handle new account balance event being reported from `Balances`
   const newAccountBalancesCallback = (e: Event) => {
     if (isCustomEvent(e) && Balances.isValidNewAccountBalanceEvent(e)) {
       const { address, ...newBalances } = e.detail
 
-      // Only update state of active accounts.
+      // Only update state of active accounts
       if (uniqueAccounts.includes(address)) {
         setStateWithRef(
           { ...activeBalancesRef.current, [address]: newBalances },
@@ -155,17 +166,17 @@ export const useActiveBalances = ({
     }
   }
 
-  // Update account balances states on initial render.
+  // Update account balances states on initial render
   //
   // If `Balances` does not return an account balances record for an account, the balance
   // has not yet synced or the provided account is still `null`. In these cases a
-  // `new-account-balance` event will be emitted when the balance is ready to be sycned with the UI.
+  // `new-account-balance` event will be emitted when the balance is ready to be sycned with the UI
   useEffect(() => {
-    // Construct new active balances state.
+    // Construct new active balances state
     const newActiveBalances: ActiveBalancesState = {}
 
     for (const account of uniqueAccounts) {
-      // Adds an active balance record if it exists in `Balances`.
+      // Adds an active balance record if it exists in `Balances`
       if (account) {
         const accountBalances = Balances.getAccountBalances(network, account)
         if (accountBalances) {
@@ -173,16 +184,16 @@ export const useActiveBalances = ({
         }
       }
     }
-    // Commit new active balances to state.
+    // Commit new active balances to state
     setStateWithRef(newActiveBalances, setActiveBalances, activeBalancesRef)
   }, [JSON.stringify(uniqueAccounts)])
 
-  // Reset state when network changes.
+  // Reset state when network changes
   useEffectIgnoreInitial(() => {
     setStateWithRef({}, setActiveBalances, activeBalancesRef)
   }, [network])
 
-  // Listen for new account balance events.
+  // Listen for new account balance events
   const documentRef = useRef<Document>(document)
 
   useEventListener(
@@ -195,6 +206,7 @@ export const useActiveBalances = ({
     activeBalances,
     getLocks,
     getBalance,
+    getNonce,
     getLedger,
     getPayee,
     getPoolMembership,

--- a/packages/app/src/hooks/useSubmitExtrinsic/index.tsx
+++ b/packages/app/src/hooks/useSubmitExtrinsic/index.tsx
@@ -92,7 +92,7 @@ export const useSubmitExtrinsic = ({
 
   // Extrinsic submission handler.
   const onSubmit = async () => {
-    if (TxSubmission.getUid(uid)?.processing) {
+    if (TxSubmission.getUid(uid)?.submitted) {
       return
     }
     if (from === null) {
@@ -119,7 +119,7 @@ export const useSubmitExtrinsic = ({
     }
 
     // Pre-submission state updates
-    TxSubmission.setUidProcessing(uid, true)
+    TxSubmission.setUidSubmitted(uid, true)
 
     // Handle signed transaction
     let signer: PolkadotSigner | undefined
@@ -158,7 +158,7 @@ export const useSubmitExtrinsic = ({
             },
             closePrompt: () => closePrompt(),
             setSubmitting: (val: boolean) =>
-              TxSubmission.setUidProcessing(uid, val),
+              TxSubmission.setUidSubmitted(uid, val),
           }).getPolkadotSigner()
           break
 

--- a/packages/app/src/library/Headers/Sync.tsx
+++ b/packages/app/src/library/Headers/Sync.tsx
@@ -42,7 +42,7 @@ export const Sync = () => {
     syncing ||
     onPoolsSyncing() ||
     onValidatorsSyncing() ||
-    uids.filter(({ processing }) => processing === true).length > 0
+    uids.filter(({ submitted }) => submitted === true).length > 0
 
   return isSyncing ? <Spinner /> : null
 }

--- a/packages/app/src/library/SubmitTx/Default.tsx
+++ b/packages/app/src/library/SubmitTx/Default.tsx
@@ -13,7 +13,7 @@ import type { SubmitProps } from './types'
 export const Default = ({
   uid,
   onSubmit,
-  processing,
+  submitted,
   valid,
   submitText,
   buttons,
@@ -23,12 +23,12 @@ export const Default = ({
 }: SubmitProps & {
   buttons?: ReactNode[]
   notEnoughFunds: boolean
-  processing: boolean
+  submitted: boolean
 }) => {
   const { accountHasSigner } = useImportedAccounts()
 
   const disabled =
-    processing || !valid || !accountHasSigner(submitAddress) || notEnoughFunds
+    submitted || !valid || !accountHasSigner(submitAddress) || notEnoughFunds
 
   return (
     <>

--- a/packages/app/src/library/SubmitTx/ManualSign/Ledger/Submit.tsx
+++ b/packages/app/src/library/SubmitTx/ManualSign/Ledger/Submit.tsx
@@ -13,7 +13,7 @@ import { ButtonSubmit } from 'ui-buttons'
 
 export const Submit = ({
   displayFor,
-  processing,
+  submitted,
   submitText,
   onSubmit,
   disabled,
@@ -30,7 +30,7 @@ export const Submit = ({
   }
 
   // Is the transaction ready to be submitted?
-  const txReady = integrityChecked || processing
+  const txReady = integrityChecked || submitted
 
   // Button `onClick` handler depends whether integrityChecked and whether tx has been submitted.
   const handleOnClick = !integrityChecked ? handleCheckRuntimeVersion : onSubmit

--- a/packages/app/src/library/SubmitTx/ManualSign/Ledger/index.tsx
+++ b/packages/app/src/library/SubmitTx/ManualSign/Ledger/index.tsx
@@ -21,7 +21,7 @@ import { Submit } from './Submit'
 export const Ledger = ({
   uid,
   onSubmit,
-  processing,
+  submitted,
   valid,
   submitText,
   buttons,
@@ -31,7 +31,7 @@ export const Ledger = ({
 }: SubmitProps & {
   buttons?: ReactNode[]
   notEnoughFunds: boolean
-  processing: boolean
+  submitted: boolean
 }) => {
   const { t } = useTranslation('library')
   const {
@@ -78,7 +78,7 @@ export const Ledger = ({
   const disabled =
     !accountHasSigner(submitAddress) ||
     !valid ||
-    processing ||
+    submitted ||
     notEnoughFunds ||
     getIsExecuting()
 
@@ -88,7 +88,7 @@ export const Ledger = ({
   }, [
     integrityChecked,
     valid,
-    processing,
+    submitted,
     notEnoughFunds,
     getStatusCode(),
     getIsExecuting(),
@@ -157,7 +157,7 @@ export const Ledger = ({
           {buttons}
           <Submit
             displayFor={displayFor}
-            processing={processing}
+            submitted={submitted}
             submitText={submitText}
             onSubmit={onSubmit}
             disabled={disabled}

--- a/packages/app/src/library/SubmitTx/ManualSign/Vault/index.tsx
+++ b/packages/app/src/library/SubmitTx/ManualSign/Vault/index.tsx
@@ -15,7 +15,7 @@ import type { SubmitProps } from '../../types'
 export const Vault = ({
   uid,
   onSubmit,
-  processing,
+  submitted,
   valid,
   submitText,
   buttons,
@@ -25,7 +25,7 @@ export const Vault = ({
 }: SubmitProps & {
   buttons?: ReactNode[]
   notEnoughFunds: boolean
-  processing: boolean
+  submitted: boolean
 }) => {
   const { t } = useTranslation('library')
   const { status: promptStatus } = usePrompt()
@@ -33,14 +33,14 @@ export const Vault = ({
 
   // The state under which submission is disabled.
   const disabled =
-    processing || !valid || !accountHasSigner(submitAddress) || notEnoughFunds
+    submitted || !valid || !accountHasSigner(submitAddress) || notEnoughFunds
 
   // Format submit button based on whether signature currently exists or submission is ongoing.
   let buttonText: string
   let buttonDisabled: boolean
   let buttonPulse: boolean
 
-  if (processing) {
+  if (submitted) {
     buttonText = submitText || ''
     buttonDisabled = disabled
     buttonPulse = !(!valid || promptStatus !== 0)

--- a/packages/app/src/library/SubmitTx/ManualSign/WalletConnect/index.tsx
+++ b/packages/app/src/library/SubmitTx/ManualSign/WalletConnect/index.tsx
@@ -16,7 +16,7 @@ import { ButtonSubmit } from 'ui-buttons'
 export const WalletConnect = ({
   uid,
   onSubmit,
-  processing,
+  submitted,
   valid,
   submitText,
   buttons,
@@ -26,7 +26,7 @@ export const WalletConnect = ({
 }: SubmitProps & {
   buttons?: ReactNode[]
   notEnoughFunds: boolean
-  processing: boolean
+  submitted: boolean
 }) => {
   const { t } = useTranslation('library')
   const { getTxSubmission } = useTxMeta()
@@ -58,7 +58,7 @@ export const WalletConnect = ({
     onSubmit()
   }
 
-  if (processing) {
+  if (submitted) {
     buttonOnClick = connectAndSubmit
     buttonDisabled = disabled
     buttonPulse = false
@@ -68,7 +68,7 @@ export const WalletConnect = ({
     buttonPulse = !disabled
   }
 
-  const buttonText = processing ? submitText || '' : t('sign')
+  const buttonText = submitted ? submitText || '' : t('sign')
 
   return (
     <div className={`inner${appendOrEmpty(displayFor === 'card', 'col')}`}>

--- a/packages/app/src/library/SubmitTx/ManualSign/index.tsx
+++ b/packages/app/src/library/SubmitTx/ManualSign/index.tsx
@@ -12,7 +12,7 @@ import { WalletConnect } from './WalletConnect'
 export const ManualSign = (
   props: SubmitProps & {
     buttons?: ReactNode[]
-    processing: boolean
+    submitted: boolean
     notEnoughFunds: boolean
   }
 ) => {

--- a/packages/app/src/library/SubmitTx/index.tsx
+++ b/packages/app/src/library/SubmitTx/index.tsx
@@ -45,7 +45,7 @@ export const SubmitTx = ({
   const txSubmission = getTxSubmission(uid)
   const from = txSubmission?.from || null
   const fee = txSubmission?.fee || 0n
-  const processing = txSubmission?.processing || false
+  const submitted = txSubmission?.submitted || false
 
   const edReserved = getEdReserved(from, existentialDeposit)
   const { free, frozen } = getBalance(from)
@@ -74,7 +74,7 @@ export const SubmitTx = ({
   submitText =
     submitText ||
     `${
-      processing
+      submitted
         ? t('submitting', { ns: 'modals' })
         : t('submit', { ns: 'modals' })
     }`
@@ -100,7 +100,7 @@ export const SubmitTx = ({
           <ManualSign
             uid={uid}
             onSubmit={onSubmit}
-            processing={processing}
+            submitted={submitted}
             valid={valid}
             submitText={submitText}
             buttons={buttons}
@@ -112,7 +112,7 @@ export const SubmitTx = ({
           <Default
             uid={uid}
             onSubmit={onSubmit}
-            processing={processing}
+            submitted={submitted}
             valid={valid}
             submitText={submitText}
             buttons={buttons}

--- a/packages/app/src/library/SubmitTx/types.ts
+++ b/packages/app/src/library/SubmitTx/types.ts
@@ -36,7 +36,7 @@ export interface SignerPromptProps {
 
 export interface LedgerSubmitProps {
   onSubmit: () => void
-  processing: boolean
+  submitted: boolean
   displayFor?: DisplayFor
   disabled: boolean
   submitText?: string

--- a/packages/app/src/overlay/modals/ManageFastUnstake/index.tsx
+++ b/packages/app/src/overlay/modals/ManageFastUnstake/index.tsx
@@ -101,7 +101,7 @@ export const ManageFastUnstake = () => {
     },
   })
 
-  const processing = getTxSubmission(submitExtrinsic.uid)?.processing || false
+  const submitted = getTxSubmission(submitExtrinsic.uid)?.submitted || false
 
   // warnings
   const warnings = getSignerWarnings(
@@ -200,7 +200,7 @@ export const ManageFastUnstake = () => {
           fromController
           valid={valid}
           submitText={
-            processing
+            submitted
               ? t('submitting')
               : t('fastUnstakeSubmit', {
                   context: isFastUnstaking ? 'cancel' : 'register',


### PR DESCRIPTION
- Refactors tx submission to be more readable. 
- Calculates nonce based on pending txs, allowing multiple txs to be submitted per block.
- Fixes an issue where multiple "in block" notifications would be delivered erroneously.
