### PR TITLE
feat: Use `useCanFastUnstake` query

### DIFF
--- a/packages/app/src/Router.tsx
+++ b/packages/app/src/Router.tsx
@@ -61,7 +61,7 @@ const RouterInner = () => {
   return (
     <ErrorBoundary FallbackComponent={ErrorFallbackApp}>
       {pluginEnabled('staking_api') && !inSetup() && activeAccount && (
-        <StakingApi activeAccount={activeAccount} />
+        <StakingApi activeAccount={activeAccount} network={network} />
       )}
       <NotificationPrompts />
       <Body>

--- a/packages/app/src/StakingApi/FastUnstakeApi.tsx
+++ b/packages/app/src/StakingApi/FastUnstakeApi.tsx
@@ -1,0 +1,24 @@
+// Copyright 2024 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useFastUnstake } from 'contexts/FastUnstake'
+import { useCanFastUnstake } from 'plugin-staking-api'
+import { useEffect } from 'react'
+import type { Props } from './types'
+
+export const FastUnstakeApi = ({ activeAccount, network }: Props) => {
+  const { setFastUnstakeStatus } = useFastUnstake()
+  const { data, loading, error } = useCanFastUnstake({
+    chain: network,
+    who: activeAccount,
+  })
+
+  // Update fast unstake status on active account change. Must be bonding
+  useEffect(() => {
+    if (!loading && !error && data?.status) {
+      setFastUnstakeStatus(data.status)
+    }
+  }, [activeAccount])
+
+  return null
+}

--- a/packages/app/src/StakingApi/FastUnstakeApi.tsx
+++ b/packages/app/src/StakingApi/FastUnstakeApi.tsx
@@ -15,10 +15,10 @@ export const FastUnstakeApi = ({ activeAccount, network }: Props) => {
 
   // Update fast unstake status on active account change. Must be bonding
   useEffect(() => {
-    if (!loading && !error && data?.status) {
-      setFastUnstakeStatus(data.status)
+    if (!loading && !error && data?.canFastUnstake) {
+      setFastUnstakeStatus(data.canFastUnstake)
     }
-  }, [activeAccount])
+  }, [JSON.stringify(data?.canFastUnstake)])
 
   return null
 }

--- a/packages/app/src/StakingApi/UnclaimedRewardsApi.tsx
+++ b/packages/app/src/StakingApi/UnclaimedRewardsApi.tsx
@@ -2,18 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useApi } from 'contexts/Api'
-import { useNetwork } from 'contexts/Network'
 import { usePayouts } from 'contexts/Payouts'
-import { ApolloProvider, client, useUnclaimedRewards } from 'plugin-staking-api'
+import { useUnclaimedRewards } from 'plugin-staking-api'
 import { useEffect } from 'react'
+import type { Props } from './types'
 
-interface Props {
-  activeAccount: string
-}
-
-const Inner = ({ activeAccount }: Props) => {
+export const UnclaimedRewardsApi = ({ activeAccount, network }: Props) => {
   const { activeEra } = useApi()
-  const { network } = useNetwork()
   const { setUnclaimedRewards } = usePayouts()
 
   const { data, loading, error } = useUnclaimedRewards({
@@ -22,6 +17,7 @@ const Inner = ({ activeAccount }: Props) => {
     fromEra: Math.max(activeEra.index.minus(1).toNumber(), 0),
   })
 
+  // Update unclaimed rewards on total change
   useEffect(() => {
     if (!loading && !error && data?.unclaimedRewards) {
       setUnclaimedRewards(data?.unclaimedRewards)
@@ -30,9 +26,3 @@ const Inner = ({ activeAccount }: Props) => {
 
   return null
 }
-
-export const StakingApi = (props: Props) => (
-  <ApolloProvider client={client}>
-    <Inner {...props} />
-  </ApolloProvider>
-)

--- a/packages/app/src/StakingApi/index.tsx
+++ b/packages/app/src/StakingApi/index.tsx
@@ -1,0 +1,28 @@
+// Copyright 2024 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useFastUnstake } from 'contexts/FastUnstake'
+import { useStaking } from 'contexts/Staking'
+import { ApolloProvider, client } from 'plugin-staking-api'
+import { useEffect } from 'react'
+import { FastUnstakeApi } from './FastUnstakeApi'
+import type { Props } from './types'
+import { UnclaimedRewardsApi } from './UnclaimedRewardsApi'
+
+export const StakingApi = (props: Props) => {
+  const { isBonding } = useStaking()
+  const { setFastUnstakeStatus } = useFastUnstake()
+
+  useEffect(() => {
+    if (!isBonding()) {
+      setFastUnstakeStatus(null)
+    }
+  }, [isBonding()])
+
+  return (
+    <ApolloProvider client={client}>
+      <UnclaimedRewardsApi {...props} />
+      {isBonding() && <FastUnstakeApi {...props} />}
+    </ApolloProvider>
+  )
+}

--- a/packages/app/src/StakingApi/types.ts
+++ b/packages/app/src/StakingApi/types.ts
@@ -1,0 +1,9 @@
+// Copyright 2024 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { NetworkId } from 'common-types'
+
+export interface Props {
+  activeAccount: string
+  network: NetworkId
+}

--- a/packages/app/src/contexts/FastUnstake/defaults.ts
+++ b/packages/app/src/contexts/FastUnstake/defaults.ts
@@ -5,11 +5,10 @@
 import type { FastUnstakeContextInterface } from './types'
 
 export const defaultFastUnstakeContext: FastUnstakeContextInterface = {
-  checking: false,
-  isExposed: null,
+  exposed: false,
   head: undefined,
   queueDeposit: undefined,
   counterForQueue: undefined,
+  fastUnstakeStatus: null,
   setFastUnstakeStatus: (status) => {},
-  lastExposed: null,
 }

--- a/packages/app/src/contexts/FastUnstake/defaults.ts
+++ b/packages/app/src/contexts/FastUnstake/defaults.ts
@@ -2,18 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import type { FastUnstakeContextInterface, MetaInterface } from './types'
-
-export const defaultMeta: MetaInterface = {
-  checked: [],
-}
+import type { FastUnstakeContextInterface } from './types'
 
 export const defaultFastUnstakeContext: FastUnstakeContextInterface = {
-  getLocalkey: (address) => '',
   checking: false,
-  meta: defaultMeta,
   isExposed: null,
   head: undefined,
   queueDeposit: undefined,
   counterForQueue: undefined,
+  setFastUnstakeStatus: (status) => {},
+  lastExposed: null,
 }

--- a/packages/app/src/contexts/FastUnstake/index.tsx
+++ b/packages/app/src/contexts/FastUnstake/index.tsx
@@ -1,9 +1,6 @@
 // Copyright 2024 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useEffectIgnoreInitial } from '@w3ux/hooks'
-import type { AnyJson } from '@w3ux/types'
-import { setStateWithRef } from '@w3ux/utils'
 import { FastUnstakeConfig } from 'api/subscribe/fastUnstakeConfig'
 import type { FastUnstakeHead } from 'api/subscribe/fastUnstakeConfig/types'
 import { FastUnstakeQueue } from 'api/subscribe/fastUnstakeQueue'
@@ -11,25 +8,18 @@ import BigNumber from 'bignumber.js'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
-import { useStaking } from 'contexts/Staking'
-import { validateLocalExposure } from 'contexts/Validators/Utils'
 import { Apis } from 'controllers/Apis'
 import { Subscriptions } from 'controllers/Subscriptions'
 import { isCustomEvent } from 'controllers/utils'
+import type { FastUnstakeStatus } from 'plugin-staking-api/types'
 import type { ReactNode } from 'react'
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
-import type { MaybeAddress } from 'types'
 import { useEventListener } from 'usehooks-ts'
-import Worker from 'workers/stakers?worker'
-import { defaultFastUnstakeContext, defaultMeta } from './defaults'
+import { defaultFastUnstakeContext } from './defaults'
 import type {
   FastUnstakeContextInterface,
   FastUnstakeQueueDeposit,
-  LocalMeta,
-  MetaInterface,
 } from './types'
-
-const worker = new Worker()
 
 export const FastUnstakeContext = createContext<FastUnstakeContextInterface>(
   defaultFastUnstakeContext
@@ -38,30 +28,13 @@ export const FastUnstakeContext = createContext<FastUnstakeContextInterface>(
 export const useFastUnstake = () => useContext(FastUnstakeContext)
 
 export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
+  const { isReady } = useApi()
   const { network } = useNetwork()
   const { activeAccount } = useActiveAccounts()
-  const { inSetup, fetchEraStakers, isBonding } = useStaking()
-  const {
-    consts,
-    isReady,
-    activeEra,
-    consts: { bondDuration },
-    networkMetrics: { fastUnstakeErasToCheckPerBlock },
-  } = useApi()
 
-  const { maxExposurePageSize } = consts
-
-  // store whether a fast unstake check is in progress
-  const [checking, setChecking] = useState<boolean>(false)
-  const checkingRef = useRef(checking)
-
-  // store whether the account is exposed for fast unstake
-  const [isExposed, setIsExposed] = useState<boolean | null>(null)
-  const isExposedRef = useRef(isExposed)
-
-  // store state of elibigility checking
-  const [meta, setMeta] = useState<MetaInterface>(defaultMeta)
-  const metaRef = useRef(meta)
+  // store fast unstake status
+  const [fastUnstakeStatus, setFastUnstakeStatus] =
+    useState<FastUnstakeStatus | null>(null)
 
   // store fastUnstake queue deposit for user
   const [queueDeposit, setQueueDeposit] = useState<FastUnstakeQueueDeposit>()
@@ -72,20 +45,10 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
   // store fastUnstake counter for queue
   const [counterForQueue, setCounterForQueue] = useState<number | undefined>()
 
-  // localStorage key to fetch local metadata
-  const getLocalkey = (a: MaybeAddress) => `${network}_fast_unstake_${a}`
-
-  // check until bond duration eras surpasssed
-  const checkToEra = activeEra.index.minus(bondDuration)
-
   // Reset state on active account change
   useEffect(() => {
     // Reset fast unstake managment state
     setQueueDeposit(undefined)
-    setStateWithRef(false, setChecking, checkingRef)
-    setStateWithRef(null, setIsExposed, isExposedRef)
-    setStateWithRef(defaultMeta, setMeta, metaRef)
-
     // Re-subscribe to fast unstake queue
     Subscriptions.remove(network, 'fastUnstakeQueue')
 
@@ -111,158 +74,6 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [isReady])
 
-  // initiate fast unstake check for accounts that are nominating but not active
-  useEffectIgnoreInitial(() => {
-    if (
-      isReady &&
-      activeAccount &&
-      !activeEra.index.isZero() &&
-      fastUnstakeErasToCheckPerBlock > 0 &&
-      isBonding()
-    ) {
-      // get any existing localStorage records for account
-      const localMeta: LocalMeta | null = getLocalMeta()
-
-      const initialMeta = localMeta
-        ? { checked: localMeta.checked }
-        : defaultMeta
-
-      // even if localMeta.isExposed is false, we don't assume a final value until current era +
-      // bondDuration is checked
-      let initialIsExposed = null
-      if (localMeta) {
-        if (bondDuration.plus(1).isEqualTo(localMeta.checked.length)) {
-          initialIsExposed = localMeta.isExposed
-        } else if (localMeta.isExposed === true) {
-          initialIsExposed = true
-        } else {
-          initialIsExposed = null
-        }
-      }
-
-      // Initial local meta: localMeta
-      setStateWithRef(initialMeta, setMeta, metaRef)
-      setStateWithRef(initialIsExposed, setIsExposed, isExposedRef)
-
-      // start process if account is inactively nominating & local fast unstake data is not
-      // complete
-      if (
-        activeAccount &&
-        !inSetup() &&
-        initialIsExposed === null &&
-        isBonding()
-      ) {
-        // if localMeta existed, start checking from the next era
-        const nextEra = localMeta?.checked.at(-1) || 0
-        const maybeNextEra = localMeta
-          ? new BigNumber(nextEra - 1)
-          : activeEra.index
-
-        // Check from the possible next era `maybeNextEra`
-        processEligibility(activeAccount, maybeNextEra)
-      }
-    }
-  }, [
-    inSetup(),
-    isReady,
-    activeEra.index,
-    fastUnstakeErasToCheckPerBlock,
-    isBonding(),
-  ])
-
-  // handle worker message on completed exposure check
-  worker.onmessage = (message: MessageEvent) => {
-    if (message) {
-      // ensure correct task received
-      const { data } = message
-      const { task } = data
-      if (task !== 'processEraForExposure') {
-        return
-      }
-
-      // ensure still same conditions
-      const { networkName, who } = data
-      if (networkName !== network || who !== activeAccount) {
-        return
-      }
-
-      const { era, exposed } = data
-
-      // ensure checked eras are in order highest first
-      const checked = metaRef.current.checked
-        .concat(Number(era))
-        .sort((a: number, b: number) => b - a)
-
-      if (!metaRef.current.checked.includes(Number(era))) {
-        // update localStorage with updated changes
-        localStorage.setItem(
-          getLocalkey(who),
-          JSON.stringify({
-            isExposed: exposed,
-            checked,
-          })
-        )
-
-        // update check metadata
-        setStateWithRef(
-          {
-            checked,
-          },
-          setMeta,
-          metaRef
-        )
-      }
-
-      if (exposed) {
-        // Account is exposed - stop checking
-        // cancel checking and update exposed state
-        setStateWithRef(false, setChecking, checkingRef)
-        setStateWithRef(true, setIsExposed, isExposedRef)
-      } else if (bondDuration.plus(1).isEqualTo(checked.length)) {
-        // successfully checked current era - bondDuration eras
-        setStateWithRef(false, setChecking, checkingRef)
-        setStateWithRef(false, setIsExposed, isExposedRef)
-      } else {
-        // Finished, not exposed
-        // continue checking the next era
-        checkEra(new BigNumber(era).minus(1))
-      }
-    }
-  }
-
-  // initiate fast unstake eligibility check
-  const processEligibility = async (a: MaybeAddress, era: BigNumber) => {
-    // ensure current era has synced
-    if (
-      era.isLessThan(0) ||
-      !bondDuration.isGreaterThan(0) ||
-      !a ||
-      checkingRef.current ||
-      !activeAccount ||
-      !isBonding()
-    ) {
-      return
-    }
-
-    setStateWithRef(true, setChecking, checkingRef)
-    checkEra(era)
-  }
-
-  // calls service worker to check exppsures for given era
-  const checkEra = async (era: BigNumber) => {
-    const exposures = await fetchEraStakers(era.toString())
-
-    worker.postMessage({
-      task: 'processEraForExposure',
-      era: era.toString(),
-      who: activeAccount,
-      networkName: network,
-      exitOnExposed: true,
-      maxExposurePageSize: maxExposurePageSize.toString(),
-      exposures,
-    })
-  }
-
   // subscribe to fastUnstake queue
   const subscribeToFastUnstakeMeta = async () => {
     const api = Apis.getApi(network)
@@ -274,30 +85,6 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
       'fastUnstakeMeta',
       new FastUnstakeConfig(network)
     )
-  }
-
-  // gets any existing fast unstake metadata for an account
-  const getLocalMeta = (): LocalMeta | null => {
-    const localMeta: AnyJson = localStorage.getItem(getLocalkey(activeAccount))
-    if (!localMeta) {
-      return null
-    }
-
-    const localMetaValidated = validateLocalExposure(
-      JSON.parse(localMeta),
-      checkToEra
-    )
-    if (!localMetaValidated) {
-      // remove if not valid
-      localStorage.removeItem(getLocalkey(activeAccount))
-      return null
-    }
-    // set validated localStorage
-    localStorage.setItem(
-      getLocalkey(activeAccount),
-      JSON.stringify(localMetaValidated)
-    )
-    return localMetaValidated
   }
 
   // Handle fast unstake meta events
@@ -333,13 +120,15 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
   return (
     <FastUnstakeContext.Provider
       value={{
-        getLocalkey,
-        checking,
-        meta,
-        isExposed,
+        // TODO: Implement from Staking API
+        checking: false,
         queueDeposit,
         head,
         counterForQueue,
+        setFastUnstakeStatus,
+        isExposed: fastUnstakeStatus === 'EXPOSED',
+        // TODO: Implement from Staking API
+        lastExposed: null,
       }}
     >
       {children}

--- a/packages/app/src/contexts/FastUnstake/index.tsx
+++ b/packages/app/src/contexts/FastUnstake/index.tsx
@@ -11,7 +11,7 @@ import { useNetwork } from 'contexts/Network'
 import { Apis } from 'controllers/Apis'
 import { Subscriptions } from 'controllers/Subscriptions'
 import { isCustomEvent } from 'controllers/utils'
-import type { FastUnstakeStatus } from 'plugin-staking-api/types'
+import type { FastUnstakeResult } from 'plugin-staking-api/types'
 import type { ReactNode } from 'react'
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
 import { useEventListener } from 'usehooks-ts'
@@ -34,7 +34,7 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
 
   // store fast unstake status
   const [fastUnstakeStatus, setFastUnstakeStatus] =
-    useState<FastUnstakeStatus | null>(null)
+    useState<FastUnstakeResult | null>(null)
 
   // store fastUnstake queue deposit for user
   const [queueDeposit, setQueueDeposit] = useState<FastUnstakeQueueDeposit>()
@@ -120,15 +120,14 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
   return (
     <FastUnstakeContext.Provider
       value={{
-        // TODO: Implement from Staking API
-        checking: false,
+        exposed:
+          !!fastUnstakeStatus?.lastExposed &&
+          fastUnstakeStatus?.status === 'EXPOSED',
         queueDeposit,
         head,
         counterForQueue,
         setFastUnstakeStatus,
-        isExposed: fastUnstakeStatus === 'EXPOSED',
-        // TODO: Implement from Staking API
-        lastExposed: null,
+        fastUnstakeStatus,
       }}
     >
       {children}

--- a/packages/app/src/contexts/FastUnstake/index.tsx
+++ b/packages/app/src/contexts/FastUnstake/index.tsx
@@ -32,17 +32,17 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
   const { network } = useNetwork()
   const { activeAccount } = useActiveAccounts()
 
-  // store fast unstake status
+  // Store fast unstake status
   const [fastUnstakeStatus, setFastUnstakeStatus] =
     useState<FastUnstakeResult | null>(null)
 
-  // store fastUnstake queue deposit for user
+  // Store fastUnstake queue deposit for user
   const [queueDeposit, setQueueDeposit] = useState<FastUnstakeQueueDeposit>()
 
-  // store fastUnstake head
+  // Store fastUnstake head
   const [head, setHead] = useState<FastUnstakeHead | undefined>()
 
-  // store fastUnstake counter for queue
+  // Store fastUnstake counter for queue
   const [counterForQueue, setCounterForQueue] = useState<number | undefined>()
 
   // Reset state on active account change
@@ -74,7 +74,6 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [isReady])
 
-  // subscribe to fastUnstake queue
   const subscribeToFastUnstakeMeta = async () => {
     const api = Apis.getApi(network)
     if (!api) {
@@ -87,7 +86,6 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
     )
   }
 
-  // Handle fast unstake meta events
   const handleNewFastUnstakeConfig = (e: Event) => {
     if (isCustomEvent(e)) {
       const { head: eventHead, counterForQueue: eventCounterForQueue } =
@@ -97,7 +95,6 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
     }
   }
 
-  // Handle fast unstake deposit events
   const handleNewFastUnstakeDeposit = (e: Event) => {
     if (isCustomEvent(e)) {
       const { address, deposit } = e.detail

--- a/packages/app/src/contexts/FastUnstake/types.ts
+++ b/packages/app/src/contexts/FastUnstake/types.ts
@@ -3,24 +3,16 @@
 
 import type { FastUnstakeHead } from 'api/subscribe/fastUnstakeConfig/types'
 import type BigNumber from 'bignumber.js'
-import type { MaybeAddress } from 'types'
-
-export interface LocalMeta {
-  isExposed: boolean
-  checked: number[]
-}
-export interface MetaInterface {
-  checked: number[]
-}
+import type { FastUnstakeStatus } from 'plugin-staking-api/types'
 
 export interface FastUnstakeContextInterface {
-  getLocalkey: (address: MaybeAddress) => string
   checking: boolean
-  meta: MetaInterface
   isExposed: boolean | null
   queueDeposit: FastUnstakeQueueDeposit | undefined
   head: FastUnstakeHead | undefined
   counterForQueue: number | undefined
+  setFastUnstakeStatus: (status: FastUnstakeStatus | null) => void
+  lastExposed: bigint | null
 }
 
 export interface FastUnstakeQueueDeposit {

--- a/packages/app/src/contexts/FastUnstake/types.ts
+++ b/packages/app/src/contexts/FastUnstake/types.ts
@@ -3,16 +3,15 @@
 
 import type { FastUnstakeHead } from 'api/subscribe/fastUnstakeConfig/types'
 import type BigNumber from 'bignumber.js'
-import type { FastUnstakeStatus } from 'plugin-staking-api/types'
+import type { FastUnstakeResult } from 'plugin-staking-api/types'
 
 export interface FastUnstakeContextInterface {
-  checking: boolean
-  isExposed: boolean | null
+  exposed: boolean
   queueDeposit: FastUnstakeQueueDeposit | undefined
   head: FastUnstakeHead | undefined
   counterForQueue: number | undefined
-  setFastUnstakeStatus: (status: FastUnstakeStatus | null) => void
-  lastExposed: bigint | null
+  fastUnstakeStatus: FastUnstakeResult | null
+  setFastUnstakeStatus: (status: FastUnstakeResult | null) => void
 }
 
 export interface FastUnstakeQueueDeposit {

--- a/packages/app/src/contexts/Validators/Utils.ts
+++ b/packages/app/src/contexts/Validators/Utils.ts
@@ -1,10 +1,8 @@
 // Copyright 2024 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AnyJson } from '@w3ux/types'
 import BigNumber from 'bignumber.js'
 import type { NetworkId } from 'common-types'
-import type { LocalMeta } from 'contexts/FastUnstake/types'
 import type {
   EraRewardPoints,
   LocalValidatorEntriesData,
@@ -47,62 +45,6 @@ export const setLocalEraValidators = (
       avgCommission,
     })
   )
-}
-
-// Validate local exposure metadata, currently used for fast unstake only
-export const validateLocalExposure = (
-  localMeta: AnyJson,
-  endEra: BigNumber
-): LocalMeta | null => {
-  const localIsExposed = localMeta?.isExposed ?? null
-  let localChecked = localMeta?.checked ?? null
-
-  // check types saved
-  if (typeof localIsExposed !== 'boolean' || !Array.isArray(localChecked)) {
-    return null
-  }
-
-  // check checked only contains numbers
-  const checkedNumeric = localChecked.every((e) => typeof e === 'number')
-  if (!checkedNumeric) {
-    return null
-  }
-
-  // remove any expired eras and sort highest first
-  localChecked = localChecked
-    .filter((e: number) => endEra.isLessThan(e))
-    .sort((a: number, b: number) => b - a)
-
-  // if no remaining eras, invalid
-  if (!localChecked.length) {
-    return null
-  }
-
-  // check if highest -> lowest are decremented, no missing eras
-  let i = 0
-  let prev = 0
-  const noMissingEras = localChecked.every((e: number) => {
-    i++
-    if (i === 1) {
-      prev = e
-      return true
-    }
-    const p = prev
-    prev = e
-    if (e === p - 1) {
-      return true
-    }
-    return false
-  })
-
-  if (!noMissingEras) {
-    return null
-  }
-
-  return {
-    isExposed: localIsExposed,
-    checked: localChecked,
-  }
 }
 
 // Check if era reward points entry exists for an era

--- a/packages/app/src/hooks/useUnstaking/index.tsx
+++ b/packages/app/src/hooks/useUnstaking/index.tsx
@@ -3,7 +3,6 @@
 
 import type { AnyJson } from '@w3ux/types'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
-import { useApi } from 'contexts/Api'
 import { useFastUnstake } from 'contexts/FastUnstake'
 import { useStaking } from 'contexts/Staking'
 import { useTransferOptions } from 'contexts/TransferOptions'
@@ -12,13 +11,12 @@ import { useNominationStatus } from '../useNominationStatus'
 
 export const useUnstaking = () => {
   const { t } = useTranslation('library')
-  const { consts, activeEra } = useApi()
   const { inSetup } = useStaking()
   const { activeAccount } = useActiveAccounts()
   const { getTransferOptions } = useTransferOptions()
   const { getNominationStatus } = useNominationStatus()
-  const { checking, head, isExposed, queueDeposit, meta } = useFastUnstake()
-  const { bondDuration } = consts
+  const { checking, head, isExposed, queueDeposit, lastExposed } =
+    useFastUnstake()
   const transferOptions = getTransferOptions(activeAccount).nominate
   const { nominees } = getNominationStatus(activeAccount, 'nominator')
 
@@ -34,17 +32,12 @@ export const useUnstaking = () => {
 
   // determine unstake button
   const getFastUnstakeText = () => {
-    const { checked } = meta
     if (checking) {
-      return `${t('fastUnstakeCheckingEras', {
-        checked: checked.length,
-        total: bondDuration.toString(),
-      })}...`
+      return `${t('fastUnstakeCheckingEras')}...`
     }
-    if (isExposed) {
-      const lastExposed = activeEra.index.minus(checked[0] || 0)
+    if (isExposed && lastExposed) {
       return t('fastUnstakeExposed', {
-        count: lastExposed.toNumber(),
+        count: Number(lastExposed),
       })
     }
     if (registered) {

--- a/packages/app/src/hooks/useUnstaking/index.tsx
+++ b/packages/app/src/hooks/useUnstaking/index.tsx
@@ -15,8 +15,8 @@ export const useUnstaking = () => {
   const { activeAccount } = useActiveAccounts()
   const { getTransferOptions } = useTransferOptions()
   const { getNominationStatus } = useNominationStatus()
-  const { checking, head, isExposed, queueDeposit, lastExposed } =
-    useFastUnstake()
+  const { head, queueDeposit, fastUnstakeStatus, exposed } = useFastUnstake()
+
   const transferOptions = getTransferOptions(activeAccount).nominate
   const { nominees } = getNominationStatus(activeAccount, 'nominator')
 
@@ -32,12 +32,9 @@ export const useUnstaking = () => {
 
   // determine unstake button
   const getFastUnstakeText = () => {
-    if (checking) {
-      return `${t('fastUnstakeCheckingEras')}...`
-    }
-    if (isExposed && lastExposed) {
+    if (exposed && fastUnstakeStatus?.lastExposed) {
       return t('fastUnstakeExposed', {
-        count: Number(lastExposed),
+        count: Number(fastUnstakeStatus.lastExposed),
       })
     }
     if (registered) {

--- a/packages/app/src/overlay/modals/ManageFastUnstake/index.tsx
+++ b/packages/app/src/overlay/modals/ManageFastUnstake/index.tsx
@@ -44,9 +44,9 @@ export const ManageFastUnstake = () => {
   const { getSignerWarnings } = useSignerWarnings()
   const { setModalResize, setModalStatus } = useOverlay().modal
   const { feeReserve, getTransferOptions } = useTransferOptions()
-  const { isExposed, counterForQueue, queueDeposit, meta } = useFastUnstake()
+  const { isExposed, counterForQueue, queueDeposit, lastExposed } =
+    useFastUnstake()
 
-  const { checked } = meta
   const controller = getBondedAccount(activeAccount)
   const allTransferOptions = getTransferOptions(activeAccount)
   const { nominate, transferrableBalance } = allTransferOptions
@@ -130,9 +130,10 @@ export const ManageFastUnstake = () => {
   }
 
   // manage last exposed
-  const lastExposedAgo = !isExposed
-    ? new BigNumber(0)
-    : activeEra.index.minus(checked[0] || 0)
+  const lastExposedAgo =
+    !isExposed || !lastExposed
+      ? new BigNumber(0)
+      : activeEra.index.minus(lastExposed.toString())
 
   const erasRemaining = BigNumber.max(1, bondDuration.minus(lastExposedAgo))
 

--- a/packages/app/src/overlay/modals/ManageFastUnstake/index.tsx
+++ b/packages/app/src/overlay/modals/ManageFastUnstake/index.tsx
@@ -44,7 +44,7 @@ export const ManageFastUnstake = () => {
   const { getSignerWarnings } = useSignerWarnings()
   const { setModalResize, setModalStatus } = useOverlay().modal
   const { feeReserve, getTransferOptions } = useTransferOptions()
-  const { isExposed, counterForQueue, queueDeposit, lastExposed } =
+  const { counterForQueue, queueDeposit, fastUnstakeStatus, exposed } =
     useFastUnstake()
 
   const controller = getBondedAccount(activeAccount)
@@ -63,12 +63,12 @@ export const ManageFastUnstake = () => {
       fastUnstakeErasToCheckPerBlock > 0 &&
         ((!isFastUnstaking &&
           enoughForDeposit &&
-          isExposed === false &&
+          fastUnstakeStatus?.status === 'NOT_EXPOSED' &&
           totalUnlockChunks === 0) ||
           isFastUnstaking)
     )
   }, [
-    isExposed,
+    fastUnstakeStatus?.status,
     fastUnstakeErasToCheckPerBlock,
     totalUnlockChunks,
     isFastUnstaking,
@@ -77,7 +77,10 @@ export const ManageFastUnstake = () => {
     feeReserve,
   ])
 
-  useEffect(() => setModalResize(), [isExposed, queueDeposit, isFastUnstaking])
+  useEffect(
+    () => setModalResize(),
+    [fastUnstakeStatus?.status, queueDeposit, isFastUnstaking]
+  )
 
   const getTx = () => {
     let tx = null
@@ -131,9 +134,9 @@ export const ManageFastUnstake = () => {
 
   // manage last exposed
   const lastExposedAgo =
-    !isExposed || !lastExposed
+    !exposed || !fastUnstakeStatus?.lastExposed
       ? new BigNumber(0)
-      : activeEra.index.minus(lastExposed.toString())
+      : activeEra.index.minus(fastUnstakeStatus.lastExposed.toString())
 
   const erasRemaining = BigNumber.max(1, bondDuration.minus(lastExposedAgo))
 
@@ -152,7 +155,7 @@ export const ManageFastUnstake = () => {
           </ModalWarnings>
         ) : null}
 
-        {isExposed ? (
+        {exposed ? (
           <>
             <ActionItem
               text={t('fastUnstakeExposedAgo', {
@@ -196,7 +199,7 @@ export const ManageFastUnstake = () => {
           </>
         )}
       </ModalPadding>
-      {!isExposed ? (
+      {!exposed ? (
         <SubmitTx
           fromController
           valid={valid}

--- a/packages/app/src/pages/Nominate/Active/Status/NominationStatus.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/NominationStatus.tsx
@@ -39,7 +39,6 @@ export const NominationStatus = ({
   const { getFastUnstakeText, isUnstaking } = useUnstaking()
   const { syncing } = useSyncing(['initialization', 'era-stakers', 'balances'])
 
-  const fastUnstakeText = getFastUnstakeText()
   const controller = getBondedAccount(activeAccount)
   const nominationStatus = getNominationStatus(activeAccount, 'nominator')
   // Determine whether to display fast unstake button or regular unstake button.
@@ -50,7 +49,7 @@ export const NominationStatus = ({
     !exposed
       ? {
           disabled: isReadOnlyAccount(controller),
-          title: fastUnstakeText,
+          title: getFastUnstakeText(),
           icon: faBolt,
           onClick: () => {
             openModal({ key: 'ManageFastUnstake', size: 'sm' })

--- a/packages/app/src/pages/Nominate/Active/Status/NominationStatus.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/NominationStatus.tsx
@@ -33,23 +33,23 @@ export const NominationStatus = ({
   const { openModal } = useOverlay().modal
   const { getBondedAccount } = useBonded()
   const { activeAccount } = useActiveAccounts()
-  const { checking, isExposed } = useFastUnstake()
   const { isReadOnlyAccount } = useImportedAccounts()
   const { getNominationStatus } = useNominationStatus()
+  const { exposed, fastUnstakeStatus } = useFastUnstake()
   const { getFastUnstakeText, isUnstaking } = useUnstaking()
   const { syncing } = useSyncing(['initialization', 'era-stakers', 'balances'])
 
   const fastUnstakeText = getFastUnstakeText()
   const controller = getBondedAccount(activeAccount)
   const nominationStatus = getNominationStatus(activeAccount, 'nominator')
-
   // Determine whether to display fast unstake button or regular unstake button.
   const unstakeButton =
     fastUnstakeErasToCheckPerBlock > 0 &&
     !nominationStatus.nominees.active.length &&
-    (checking || !isExposed)
+    fastUnstakeStatus !== null &&
+    !exposed
       ? {
-          disabled: checking || isReadOnlyAccount(controller),
+          disabled: isReadOnlyAccount(controller),
           title: fastUnstakeText,
           icon: faBolt,
           onClick: () => {

--- a/packages/app/src/pages/Nominate/Active/index.tsx
+++ b/packages/app/src/pages/Nominate/Active/index.tsx
@@ -48,8 +48,8 @@ export const Active = () => {
         <MinimumActiveStake />
       </StatBoxList>
       <CommissionPrompt />
-      <WithdrawPrompt bondFor="nominator" />
 
+      {!isFastUnstaking && <WithdrawPrompt bondFor="nominator" />}
       <UnstakePrompts />
       <PageRow>
         <RowSection secondary vLast>

--- a/packages/app/src/workers/types.ts
+++ b/packages/app/src/workers/types.ts
@@ -28,13 +28,3 @@ export interface ProcessExposuresResponse {
   activeValidators: number
   who: MaybeAddress
 }
-
-export interface ProcessEraForExposureArgs {
-  era: string
-  maxExposurePageSize: string
-  exposures: Exposure[]
-  exitOnExposed: boolean
-  task: string
-  networkName: NetworkId
-  who: MaybeAddress
-}

--- a/packages/locales/src/resources/cn/library.json
+++ b/packages/locales/src/resources/cn/library.json
@@ -80,7 +80,7 @@
     "exclude": "不含",
     "failed": "失败",
     "fastUnstake": "快速解除抵押",
-    "fastUnstakeCheckingEras": "正在查验 {{total}} Eras中的 {{checked}}",
+    "fastUnstakeCheckingEras": "正在查验 Eras",
     "fastUnstakeExposed": "在 {{count}} Era前己被显示",
     "favorite": "收藏夹",
     "favoritePoolAdded": "己添加提名池",

--- a/packages/locales/src/resources/cn/library.json
+++ b/packages/locales/src/resources/cn/library.json
@@ -80,7 +80,6 @@
     "exclude": "不含",
     "failed": "失败",
     "fastUnstake": "快速解除抵押",
-    "fastUnstakeCheckingEras": "正在查验 Eras",
     "fastUnstakeExposed": "在 {{count}} Era前己被显示",
     "favorite": "收藏夹",
     "favoritePoolAdded": "己添加提名池",

--- a/packages/locales/src/resources/en/library.json
+++ b/packages/locales/src/resources/en/library.json
@@ -81,7 +81,7 @@
     "exclude": "Exclude",
     "failed": "Failed",
     "fastUnstake": "Fast Unstake",
-    "fastUnstakeCheckingEras": "Checking {{checked}} of {{total}} Eras",
+    "fastUnstakeCheckingEras": "Checking Eras",
     "fastUnstakeExposed_one": "Exposed {{count}} Era Ago",
     "fastUnstakeExposed_other": "Exposed {{count}} Eras Ago",
     "favorite": "Favorite",

--- a/packages/locales/src/resources/en/library.json
+++ b/packages/locales/src/resources/en/library.json
@@ -81,7 +81,6 @@
     "exclude": "Exclude",
     "failed": "Failed",
     "fastUnstake": "Fast Unstake",
-    "fastUnstakeCheckingEras": "Checking Eras",
     "fastUnstakeExposed_one": "Exposed {{count}} Era Ago",
     "fastUnstakeExposed_other": "Exposed {{count}} Eras Ago",
     "favorite": "Favorite",

--- a/packages/plugin-staking-api/src/index.tsx
+++ b/packages/plugin-staking-api/src/index.tsx
@@ -4,6 +4,7 @@
 import { ApolloProvider } from '@apollo/client'
 
 export * from './Client'
+export * from './queries/useCanFastUnstake'
 export * from './queries/usePoolRewards'
 export * from './queries/useRewards'
 export * from './queries/useTokenPrice'

--- a/packages/plugin-staking-api/src/queries/useCanFastUnstake.tsx
+++ b/packages/plugin-staking-api/src/queries/useCanFastUnstake.tsx
@@ -1,0 +1,26 @@
+// Copyright 2024 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { gql, useQuery } from '@apollo/client'
+import type { CanFastUnstakeResult } from '../types'
+
+const QUERY = gql`
+  query PoolRewards($chain: String!, $who: String!) {
+    canFastUnstake(chain: $chain, who: $who) {
+      status
+    }
+  }
+`
+
+export const useCanFastUnstake = ({
+  chain,
+  who,
+}: {
+  chain: string
+  who: string
+}): CanFastUnstakeResult => {
+  const { loading, error, data, refetch } = useQuery(QUERY, {
+    variables: { chain, who },
+  })
+  return { loading, error, data, refetch }
+}

--- a/packages/plugin-staking-api/src/types.ts
+++ b/packages/plugin-staking-api/src/types.ts
@@ -54,6 +54,18 @@ export type PoolRewardResults = Query & {
   }
 }
 
+export type FastUnstakeStatus =
+  | 'UNSUPPORTED_CHAIN'
+  | 'NOT_PROCESSED'
+  | 'NOT_EXPOSED'
+  | 'EXPOSED'
+
+export type CanFastUnstakeResult = Query & {
+  data: {
+    status: FastUnstakeStatus
+  }
+}
+
 export interface UnclaimedRewards {
   total: string
   entries: EraUnclaimedReward[]

--- a/packages/plugin-staking-api/src/types.ts
+++ b/packages/plugin-staking-api/src/types.ts
@@ -60,9 +60,14 @@ export type FastUnstakeStatus =
   | 'NOT_EXPOSED'
   | 'EXPOSED'
 
+export interface FastUnstakeResult {
+  status: FastUnstakeStatus
+  lastExposed?: number
+}
+
 export type CanFastUnstakeResult = Query & {
   data: {
-    status: FastUnstakeStatus
+    canFastUnstake: FastUnstakeResult
   }
 }
 


### PR DESCRIPTION
Determines whether nominators can fast unstake via Staking API call `canFastUnstake`, and discontinues legacy era stakers scraping from the node.

- [x] Replace local era stakers checking with Staking API call
- [x] Retrieve `lastExposed` from Staking API and use in FastUnstake context
- [x] Only enable Fast Unstake button if Staking API is enabled
- [x] Tests and polish