### PR TITLE
feat(refactor): Use Staking API for validator era points

### DIFF
--- a/packages/app/src/Router.tsx
+++ b/packages/app/src/Router.tsx
@@ -19,6 +19,7 @@ import { SideMenu } from 'library/SideMenu'
 import { Tooltip } from 'library/Tooltip'
 import { Offline } from 'Offline'
 import { Overlays } from 'overlay'
+import { ApolloProvider, client } from 'plugin-staking-api'
 import { useEffect, useRef } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { HelmetProvider } from 'react-helmet-async'
@@ -59,41 +60,43 @@ const RouterInner = () => {
 
   return (
     <ErrorBoundary FallbackComponent={ErrorFallbackApp}>
-      {pluginEnabled('staking_api') && activeAccount && (
-        <StakingApi activeAccount={activeAccount} network={network} />
-      )}
-      <NotificationPrompts />
-      <Body>
-        <Help />
-        <Overlays />
-        <Menu />
-        <Tooltip />
-        <Prompt />
-        <SideMenu />
-        <Main ref={mainInterfaceRef}>
-          <HelmetProvider>
-            <Headers />
-            <ErrorBoundary FallbackComponent={ErrorFallbackRoutes}>
-              <Routes>
-                {PagesConfig.map((page, i) => (
+      <ApolloProvider client={client}>
+        {pluginEnabled('staking_api') && activeAccount && (
+          <StakingApi activeAccount={activeAccount} network={network} />
+        )}
+        <NotificationPrompts />
+        <Body>
+          <Help />
+          <Overlays />
+          <Menu />
+          <Tooltip />
+          <Prompt />
+          <SideMenu />
+          <Main ref={mainInterfaceRef}>
+            <HelmetProvider>
+              <Headers />
+              <ErrorBoundary FallbackComponent={ErrorFallbackRoutes}>
+                <Routes>
+                  {PagesConfig.map((page, i) => (
+                    <Route
+                      key={`main_interface_page_${i}`}
+                      path={page.hash}
+                      element={<PageWithTitle page={page} />}
+                    />
+                  ))}
                   <Route
-                    key={`main_interface_page_${i}`}
-                    path={page.hash}
-                    element={<PageWithTitle page={page} />}
+                    key="main_interface_navigate"
+                    path="*"
+                    element={<Navigate to="/overview" />}
                   />
-                ))}
-                <Route
-                  key="main_interface_navigate"
-                  path="*"
-                  element={<Navigate to="/overview" />}
-                />
-              </Routes>
-            </ErrorBoundary>
-            <MainFooter />
-          </HelmetProvider>
-        </Main>
-      </Body>
-      <Offline />
+                </Routes>
+              </ErrorBoundary>
+              <MainFooter />
+            </HelmetProvider>
+          </Main>
+        </Body>
+        <Offline />
+      </ApolloProvider>
     </ErrorBoundary>
   )
 }

--- a/packages/app/src/StakingApi/index.tsx
+++ b/packages/app/src/StakingApi/index.tsx
@@ -3,7 +3,6 @@
 
 import { useFastUnstake } from 'contexts/FastUnstake'
 import { useStaking } from 'contexts/Staking'
-import { ApolloProvider, client } from 'plugin-staking-api'
 import { useEffect } from 'react'
 import { FastUnstakeApi } from './FastUnstakeApi'
 import type { Props } from './types'
@@ -20,9 +19,9 @@ export const StakingApi = (props: Props) => {
   }, [isBonding()])
 
   return (
-    <ApolloProvider client={client}>
+    <>
       <UnclaimedRewardsApi {...props} />
       {isBonding() && <FastUnstakeApi {...props} />}
-    </ApolloProvider>
+    </>
   )
 }

--- a/packages/app/src/library/Graphs/EraPoints.tsx
+++ b/packages/app/src/library/Graphs/EraPoints.tsx
@@ -65,6 +65,7 @@ export const EraPoints = ({ items = [], height }: EraPointsProps) => {
         grid: {
           color: graphColors.grid[mode],
         },
+        min: 0,
         ticks: {
           display: true,
           beginAtZero: false,
@@ -100,13 +101,11 @@ export const EraPoints = ({ items = [], height }: EraPointsProps) => {
   }
 
   const data = {
-    labels: items.map(({ era }: { era: string }) => era),
+    labels: items.map(({ era }) => era),
     datasets: [
       {
         label: t('points'),
-        data: items.map(
-          ({ reward_point }: { reward_point: string }) => reward_point
-        ),
+        data: items.map(({ points }) => points),
         borderColor: colors.primary[mode],
         backgroundColor: colors.primary[mode],
         pointStyle: undefined,

--- a/packages/app/src/library/Graphs/types.ts
+++ b/packages/app/src/library/Graphs/types.ts
@@ -3,7 +3,11 @@
 
 import type BigNumber from 'bignumber.js'
 import type { AnyApi } from 'common-types'
-import type { NominatorReward, PoolReward } from 'plugin-staking-api/types'
+import type {
+  NominatorReward,
+  PoolReward,
+  ValidatorEraPoints,
+} from 'plugin-staking-api/types'
 
 export interface BondedProps {
   active: BigNumber
@@ -14,7 +18,7 @@ export interface BondedProps {
 }
 
 export interface EraPointsProps {
-  items: AnyApi
+  items: ValidatorEraPoints[]
   height: number
 }
 

--- a/packages/app/src/library/MainFooter/TokenPrice.tsx
+++ b/packages/app/src/library/MainFooter/TokenPrice.tsx
@@ -4,16 +4,11 @@
 import { useEffectIgnoreInitial } from '@w3ux/hooks'
 import { useNetwork } from 'contexts/Network'
 import { isCustomEvent } from 'controllers/utils'
-import {
-  ApolloProvider,
-  client,
-  formatTokenPrice,
-  useTokenPrice,
-} from 'plugin-staking-api'
+import { formatTokenPrice, useTokenPrice } from 'plugin-staking-api'
 import { useRef } from 'react'
 import { useEventListener } from 'usehooks-ts'
 
-export const TokenPriceInner = () => {
+export const TokenPrice = () => {
   const {
     networkData: {
       api: { unit },
@@ -68,9 +63,3 @@ export const TokenPriceInner = () => {
     </>
   )
 }
-
-export const TokenPrice = () => (
-  <ApolloProvider client={client}>
-    <TokenPriceInner />
-  </ApolloProvider>
-)

--- a/packages/app/src/overlay/modals/ValidatorMetrics/ActiveGraph.tsx
+++ b/packages/app/src/overlay/modals/ValidatorMetrics/ActiveGraph.tsx
@@ -1,0 +1,38 @@
+// Copyright 2024 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { NetworkId } from 'common-types'
+import { EraPoints } from 'library/Graphs/EraPoints'
+import {
+  ApolloProvider,
+  client,
+  useValidatorEraPoints,
+} from 'plugin-staking-api'
+
+interface Props {
+  network: NetworkId
+  validator: string
+  fromEra: number
+}
+export const Inner = ({ network, validator, fromEra }: Props) => {
+  const { data, loading, error } = useValidatorEraPoints({
+    chain: network,
+    validator,
+    fromEra,
+  })
+
+  const list =
+    loading || error || data?.validatorEraPoints === undefined
+      ? []
+      : data.validatorEraPoints
+
+  const sorted = [...list].sort((a, b) => a.era - b.era)
+
+  return <EraPoints items={sorted} height={250} />
+}
+
+export const ActiveGraph = (props: Props) => (
+  <ApolloProvider client={client}>
+    <Inner {...props} />
+  </ApolloProvider>
+)

--- a/packages/app/src/overlay/modals/ValidatorMetrics/ActiveGraph.tsx
+++ b/packages/app/src/overlay/modals/ValidatorMetrics/ActiveGraph.tsx
@@ -3,18 +3,14 @@
 
 import type { NetworkId } from 'common-types'
 import { EraPoints } from 'library/Graphs/EraPoints'
-import {
-  ApolloProvider,
-  client,
-  useValidatorEraPoints,
-} from 'plugin-staking-api'
+import { useValidatorEraPoints } from 'plugin-staking-api'
 
 interface Props {
   network: NetworkId
   validator: string
   fromEra: number
 }
-export const Inner = ({ network, validator, fromEra }: Props) => {
+export const ActiveGraph = ({ network, validator, fromEra }: Props) => {
   const { data, loading, error } = useValidatorEraPoints({
     chain: network,
     validator,
@@ -30,9 +26,3 @@ export const Inner = ({ network, validator, fromEra }: Props) => {
 
   return <EraPoints items={sorted} height={250} />
 }
-
-export const ActiveGraph = (props: Props) => (
-  <ApolloProvider client={client}>
-    <Inner {...props} />
-  </ApolloProvider>
-)

--- a/packages/app/src/overlay/modals/ValidatorMetrics/index.tsx
+++ b/packages/app/src/overlay/modals/ValidatorMetrics/index.tsx
@@ -15,7 +15,6 @@ import { formatSize } from 'library/Graphs/Utils'
 import { GraphWrapper } from 'library/Graphs/Wrapper'
 import { Title } from 'library/Modal/Title'
 import { StatWrapper, StatsWrapper } from 'library/Modal/Wrappers'
-import { PluginLabel } from 'library/PluginLabel'
 import { StatusLabel } from 'library/StatusLabel'
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -103,7 +102,6 @@ export const ValidatorMetrics = () => {
       <div
         style={{ position: 'relative', marginTop: '0.5rem', padding: '1rem' }}
       >
-        <PluginLabel plugin="subscan" />
         <CardWrapper
           className="transparent"
           style={{

--- a/packages/app/src/overlay/modals/ValidatorMetrics/index.tsx
+++ b/packages/app/src/overlay/modals/ValidatorMetrics/index.tsx
@@ -3,38 +3,35 @@
 
 import { useSize } from '@w3ux/hooks'
 import { Polkicon } from '@w3ux/react-polkicon'
-import type { AnyJson } from '@w3ux/types'
 import { ellipsisFn } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
 import { useApi } from 'contexts/Api'
 import { useHelp } from 'contexts/Help'
 import { useNetwork } from 'contexts/Network'
-import { usePlugins } from 'contexts/Plugins'
 import { useStaking } from 'contexts/Staking'
 import { useUi } from 'contexts/UI'
-import { Subscan } from 'controllers/Subscan'
 import { CardHeaderWrapper, CardWrapper } from 'library/Card/Wrappers'
-import { EraPoints as EraPointsGraph } from 'library/Graphs/EraPoints'
 import { formatSize } from 'library/Graphs/Utils'
 import { GraphWrapper } from 'library/Graphs/Wrapper'
 import { Title } from 'library/Modal/Title'
 import { StatWrapper, StatsWrapper } from 'library/Modal/Wrappers'
 import { PluginLabel } from 'library/PluginLabel'
 import { StatusLabel } from 'library/StatusLabel'
-import { useEffect, useRef, useState } from 'react'
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ButtonHelp } from 'ui-buttons'
 import { AddressHeader, Padding } from 'ui-core/modal'
 import { useOverlay } from 'ui-overlay'
 import { planckToUnitBn } from 'utils'
+import { ActiveGraph } from './ActiveGraph'
 
 export const ValidatorMetrics = () => {
   const { t } = useTranslation('modals')
   const {
+    network,
     networkData: { units, unit },
   } = useNetwork()
   const { activeEra } = useApi()
-  const { plugins } = usePlugins()
   const { containerRefs } = useUi()
   const { options } = useOverlay().modal.config
   const { address, identity } = options
@@ -58,26 +55,12 @@ export const ValidatorMetrics = () => {
       validatorOwnStake = new BigNumber(own)
     }
   }
-  const [list, setList] = useState<AnyJson[]>([])
 
   const ref = useRef<HTMLDivElement>(null)
   const size = useSize(ref, {
     outerElement: containerRefs?.mainInterface,
   })
   const { width, height, minHeight } = formatSize(size, 300)
-
-  const handleEraPoints = async () => {
-    if (!plugins.includes('subscan')) {
-      return
-    }
-    setList(
-      await Subscan.handleFetchEraPoints(address, activeEra.index.toNumber())
-    )
-  }
-
-  useEffect(() => {
-    handleEraPoints()
-  }, [])
 
   const stats = [
     {
@@ -146,7 +129,11 @@ export const ValidatorMetrics = () => {
                 width: `${width}px`,
               }}
             >
-              <EraPointsGraph items={list} height={250} />
+              <ActiveGraph
+                network={network}
+                validator={address}
+                fromEra={BigNumber.max(activeEra.index.minus(1), 0).toNumber()}
+              />
             </GraphWrapper>
           </div>
         </CardWrapper>

--- a/packages/app/src/pages/Overview/AccountBalance/FiatValue.tsx
+++ b/packages/app/src/pages/Overview/AccountBalance/FiatValue.tsx
@@ -4,18 +4,13 @@
 import { useEffectIgnoreInitial } from '@w3ux/hooks'
 import BigNumber from 'bignumber.js'
 import { useNetwork } from 'contexts/Network'
-import {
-  ApolloProvider,
-  client,
-  formatTokenPrice,
-  useTokenPrice,
-} from 'plugin-staking-api'
+import { formatTokenPrice, useTokenPrice } from 'plugin-staking-api'
 
 interface FiatValueProps {
   totalBalance: BigNumber
 }
 
-export const FiatValueInner = ({ totalBalance }: FiatValueProps) => {
+export const FiatValue = ({ totalBalance }: FiatValueProps) => {
   const {
     networkData: {
       api: { unit },
@@ -47,9 +42,3 @@ export const FiatValueInner = ({ totalBalance }: FiatValueProps) => {
 
   return <>{usdFormatter.format(freeFiat.toNumber())}</>
 }
-
-export const FiatValue = (props: FiatValueProps) => (
-  <ApolloProvider client={client}>
-    <FiatValueInner {...props} />
-  </ApolloProvider>
-)

--- a/packages/app/src/pages/Overview/Payouts/ActiveGraph.tsx
+++ b/packages/app/src/pages/Overview/Payouts/ActiveGraph.tsx
@@ -7,12 +7,7 @@ import { useNetwork } from 'contexts/Network'
 import { getUnixTime } from 'date-fns'
 import { PayoutBar } from 'library/Graphs/PayoutBar'
 import { PayoutLine } from 'library/Graphs/PayoutLine'
-import {
-  ApolloProvider,
-  client,
-  usePoolRewards,
-  useRewards,
-} from 'plugin-staking-api'
+import { usePoolRewards, useRewards } from 'plugin-staking-api'
 import type {
   NominatorReward,
   RewardResult,
@@ -26,7 +21,7 @@ interface Props {
   lineMarginTop: string
   setLastReward: (reward: RewardResult | undefined) => void
 }
-export const ActiveGraphInner = ({
+export const ActiveGraph = ({
   nominating,
   inPool,
   lineMarginTop,
@@ -94,9 +89,3 @@ export const ActiveGraphInner = ({
     </>
   )
 }
-
-export const ActiveGraph = (props: Props) => (
-  <ApolloProvider client={client}>
-    <ActiveGraphInner {...props} />
-  </ApolloProvider>
-)

--- a/packages/app/src/pages/Payouts/ActiveGraph.tsx
+++ b/packages/app/src/pages/Payouts/ActiveGraph.tsx
@@ -10,12 +10,7 @@ import { getUnixTime } from 'date-fns'
 import { PayoutBar } from 'library/Graphs/PayoutBar'
 import { PayoutLine } from 'library/Graphs/PayoutLine'
 import { removeNonZeroAmountAndSort } from 'library/Graphs/Utils'
-import {
-  ApolloProvider,
-  client,
-  usePoolRewards,
-  useRewards,
-} from 'plugin-staking-api'
+import { usePoolRewards, useRewards } from 'plugin-staking-api'
 import type { NominatorReward, RewardResults } from 'plugin-staking-api/types'
 import { useEffect } from 'react'
 
@@ -25,11 +20,7 @@ interface Props {
   setPayoutLists: (payouts: AnyApi[]) => void
 }
 
-export const ActiveGraphInner = ({
-  nominating,
-  inPool,
-  setPayoutLists,
-}: Props) => {
+export const ActiveGraph = ({ nominating, inPool, setPayoutLists }: Props) => {
   const { activeEra } = useApi()
   const { network } = useNetwork()
   const { activeAccount } = useActiveAccounts()
@@ -87,9 +78,3 @@ export const ActiveGraphInner = ({
     </>
   )
 }
-
-export const ActiveGraph = (props: Props) => (
-  <ApolloProvider client={client}>
-    <ActiveGraphInner {...props} />
-  </ApolloProvider>
-)

--- a/packages/plugin-staking-api/src/index.tsx
+++ b/packages/plugin-staking-api/src/index.tsx
@@ -9,6 +9,7 @@ export * from './queries/usePoolRewards'
 export * from './queries/useRewards'
 export * from './queries/useTokenPrice'
 export * from './queries/useUnclaimedRewards'
+export * from './queries/useValidatorEraPoints'
 export * from './util'
 
 export { ApolloProvider }

--- a/packages/plugin-staking-api/src/queries/useValidatorEraPoints.tsx
+++ b/packages/plugin-staking-api/src/queries/useValidatorEraPoints.tsx
@@ -1,0 +1,37 @@
+// Copyright 2024 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { gql, useQuery } from '@apollo/client'
+import type { ValidatorEraPointsResult } from '../types'
+
+const QUERY = gql`
+  query ValidatorEraPoints(
+    $chain: String!
+    $validator: String!
+    $fromEra: Int!
+  ) {
+    validatorEraPoints(
+      chain: $chain
+      validator: $validator
+      fromEra: $fromEra
+    ) {
+      era
+      points
+    }
+  }
+`
+
+export const useValidatorEraPoints = ({
+  chain,
+  validator,
+  fromEra,
+}: {
+  chain: string
+  validator: string
+  fromEra: number
+}): ValidatorEraPointsResult => {
+  const { loading, error, data, refetch } = useQuery(QUERY, {
+    variables: { chain, validator, fromEra },
+  })
+  return { loading, error, data, refetch }
+}

--- a/packages/plugin-staking-api/src/types.ts
+++ b/packages/plugin-staking-api/src/types.ts
@@ -71,6 +71,12 @@ export type CanFastUnstakeResult = Query & {
   }
 }
 
+export type ValidatorEraPointsResult = Query & {
+  data: {
+    validatorEraPoints: ValidatorEraPoints[]
+  }
+}
+
 export interface UnclaimedRewards {
   total: string
   entries: EraUnclaimedReward[]
@@ -85,6 +91,11 @@ export interface ValidatorUnclaimedReward {
   validator: string
   reward: string
   page: number | null
+}
+
+export interface ValidatorEraPoints {
+  era: number
+  points: string
 }
 
 export interface PoolReward {


### PR DESCRIPTION
- Replaces Subscan validator era points fetching with Staking API.
- Opts for one global `<ApolloProvider>` that is not removed on plugin toggling.