### PR TITLE
fix: improve `color` contrast for dark theme button

### DIFF
--- a/packages/styles/theme/index.scss
+++ b/packages/styles/theme/index.scss
@@ -88,6 +88,7 @@ button {
   cursor: pointer;
   margin: 0;
   padding: 0;
+  color: var(--text-color-secondary);
 }
 
 input {

--- a/packages/ui-core/src/modal/Close/index.module.scss
+++ b/packages/ui-core/src/modal/Close/index.module.scss
@@ -7,7 +7,7 @@
   top: 1.5rem;
   z-index: 2;
   > button {
-    opacity: 0.4;
+    opacity: 0.6;
     transition: opacity var(--transition-duration) ease-in-out;
     &:hover {
       opacity: 1;


### PR DESCRIPTION
Minor CSS tweak fixing https://github.com/polkadot-cloud/polkadot-staking-dashboard/issues/2419

![image](https://github.com/user-attachments/assets/ef341e6b-cddb-4f01-9204-47ec8134edce)

![image](https://github.com/user-attachments/assets/c7229ab3-6dbb-4dda-877a-e2751f83553f)

Manually tested in latest Firefox and Chromium.

