### PR TITLE
feat(ux): Get theme values directly from CSS, discontinue network colors

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -4,6 +4,7 @@
 import { ActiveAccountsProvider } from 'contexts/ActiveAccounts'
 import { NetworkProvider } from 'contexts/Network'
 import { ThemesProvider } from 'contexts/Themes'
+import { ThemeValuesProvider } from 'contexts/ThemeValues'
 import { i18next } from 'locales'
 import { Providers } from 'Providers'
 import { I18nextProvider } from 'react-i18next'
@@ -11,11 +12,13 @@ import { I18nextProvider } from 'react-i18next'
 export const App = () => (
   <I18nextProvider i18n={i18next}>
     <ThemesProvider>
-      <NetworkProvider>
-        <ActiveAccountsProvider>
-          <Providers />
-        </ActiveAccountsProvider>
-      </NetworkProvider>
+      <ThemeValuesProvider>
+        <NetworkProvider>
+          <ActiveAccountsProvider>
+            <Providers />
+          </ActiveAccountsProvider>
+        </NetworkProvider>
+      </ThemeValuesProvider>
     </ThemesProvider>
   </I18nextProvider>
 )

--- a/packages/app/src/Themes.tsx
+++ b/packages/app/src/Themes.tsx
@@ -3,6 +3,7 @@
 
 import { Router } from 'Router'
 import { useNetwork } from 'contexts/Network'
+import { ThemeValuesProvider } from 'contexts/ThemeValues'
 import { useTheme } from 'contexts/Themes'
 import { useEffect } from 'react'
 import { ThemeProvider } from 'styled-components'
@@ -25,7 +26,9 @@ export const ThemedRouter = () => {
   return (
     <ThemeProvider theme={{ mode }}>
       <Entry mode={mode} theme={`${network}-relay`} ref={themeElementRef}>
-        <Router />
+        <ThemeValuesProvider>
+          <Router />
+        </ThemeValuesProvider>
       </Entry>
     </ThemeProvider>
   )

--- a/packages/app/src/Themes.tsx
+++ b/packages/app/src/Themes.tsx
@@ -10,8 +10,8 @@ import { Entry } from 'ui-core/base'
 
 // light / dark `mode` added to styled-components provider
 export const ThemedRouter = () => {
-  const { mode } = useTheme()
   const { network } = useNetwork()
+  const { mode, themeElementRef } = useTheme()
 
   // Update body background to `--background-default` color upon theme change.
   useEffect(() => {
@@ -24,7 +24,7 @@ export const ThemedRouter = () => {
 
   return (
     <ThemeProvider theme={{ mode }}>
-      <Entry mode={mode} theme={`${network}-relay`}>
+      <Entry mode={mode} theme={`${network}-relay`} ref={themeElementRef}>
         <Router />
       </Entry>
     </ThemeProvider>

--- a/packages/app/src/Themes.tsx
+++ b/packages/app/src/Themes.tsx
@@ -3,7 +3,6 @@
 
 import { Router } from 'Router'
 import { useNetwork } from 'contexts/Network'
-import { ThemeValuesProvider } from 'contexts/ThemeValues'
 import { useTheme } from 'contexts/Themes'
 import { useEffect } from 'react'
 import { ThemeProvider } from 'styled-components'
@@ -26,9 +25,7 @@ export const ThemedRouter = () => {
   return (
     <ThemeProvider theme={{ mode }}>
       <Entry mode={mode} theme={`${network}-relay`} ref={themeElementRef}>
-        <ThemeValuesProvider>
-          <Router />
-        </ThemeValuesProvider>
+        <Router />
       </Entry>
     </ThemeProvider>
   )

--- a/packages/app/src/common-types.ts
+++ b/packages/app/src/common-types.ts
@@ -23,7 +23,6 @@ import type {
 import type { ActiveBalance } from 'contexts/Balances/types'
 import type { BondedAccount } from 'contexts/Bonded/types'
 import type { FastUnstakeQueueResult } from 'contexts/FastUnstake/types'
-import type { Theme } from 'contexts/Themes/types'
 import type { NotificationItem } from 'controllers/Notifications/types'
 import type { OnlineStatusEvent } from 'controllers/OnlineStatus/types'
 import type { SyncEvent } from 'controllers/Syncs/types'
@@ -76,12 +75,6 @@ export type SystemChainId =
 
 export type Networks = Record<string, Network>
 
-type NetworkColor =
-  | 'primary'
-  | 'secondary'
-  | 'stroke'
-  | 'transparent'
-  | 'pending'
 export interface Network {
   name: NetworkId
   endpoints: {
@@ -91,7 +84,6 @@ export interface Network {
     rpcEndpoints: Record<string, string>
   }
 
-  colors: Record<NetworkColor, { [key in Theme]: string }>
   unit: string
   units: number
   ss58: number

--- a/packages/app/src/config/networks.ts
+++ b/packages/app/src/config/networks.ts
@@ -31,28 +31,6 @@ export const NetworkList: Networks = {
         Stakeworld: 'wss://dot-rpc.stakeworld.io',
       },
     },
-    colors: {
-      primary: {
-        light: 'rgb(211, 48, 121)',
-        dark: 'rgb(211, 48, 121)',
-      },
-      secondary: {
-        light: 'rgb(110, 71, 207)',
-        dark: 'rgb(110, 71, 207)',
-      },
-      stroke: {
-        light: 'rgb(211, 48, 121)',
-        dark: 'rgb(211, 48, 121)',
-      },
-      transparent: {
-        light: 'rgb(211, 48, 121, 0.05)',
-        dark: 'rgb(211, 48, 121, 0.05)',
-      },
-      pending: {
-        light: 'rgb(211, 48, 121, 0.33)',
-        dark: 'rgb(211, 48, 121, 0.33)',
-      },
-    },
     unit: 'DOT',
     units: 10,
     ss58: 0,
@@ -87,28 +65,6 @@ export const NetworkList: Networks = {
         Stakeworld: 'wss://ksm-rpc.stakeworld.io',
       },
     },
-    colors: {
-      primary: {
-        light: 'rgb(126 131 141)',
-        dark: 'rgb(126 131 141)',
-      },
-      secondary: {
-        light: 'rgb(141 144 150)',
-        dark: 'rgb(141, 144, 150)',
-      },
-      stroke: {
-        light: '#4c4b63',
-        dark: '#d1d1db',
-      },
-      transparent: {
-        light: 'rgb(51,51,51,0.05)',
-        dark: 'rgb(102,102,102, 0.05)',
-      },
-      pending: {
-        light: 'rgb(51,51,51,0.33)',
-        dark: 'rgb(102,102,102, 0.33)',
-      },
-    },
     unit: 'KSM',
     units: 12,
     ss58: 2,
@@ -140,28 +96,6 @@ export const NetworkList: Networks = {
         LuckyFriday: 'wss://rpc-westend.luckyfriday.io',
         RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws',
         Stakeworld: 'wss://wnd-rpc.stakeworld.io',
-      },
-    },
-    colors: {
-      primary: {
-        light: '#da4e71',
-        dark: '#da4e71',
-      },
-      secondary: {
-        light: '#de6a50',
-        dark: '#de6a50',
-      },
-      stroke: {
-        light: '#da4e71',
-        dark: '#da4e71',
-      },
-      transparent: {
-        light: 'rgb(218, 78, 113, 0.05)',
-        dark: 'rgb(218, 78, 113, 0.05)',
-      },
-      pending: {
-        light: 'rgb(218, 78, 113, 0.33)',
-        dark: 'rgb(218, 78, 113, 0.33)',
       },
     },
     unit: 'WND',

--- a/packages/app/src/contexts/ThemeValues/defaults.ts
+++ b/packages/app/src/contexts/ThemeValues/defaults.ts
@@ -1,0 +1,10 @@
+// Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import type { ThemeValuesContextInterface } from './types'
+
+// SPDX-License-Identifier: GPL-3.0-only
+export const defaultThemeValuesContext: ThemeValuesContextInterface = {
+  getThemeValue: (name) => '',
+}

--- a/packages/app/src/contexts/ThemeValues/index.tsx
+++ b/packages/app/src/contexts/ThemeValues/index.tsx
@@ -26,7 +26,7 @@ export const ThemeValuesProvider = ({ children }: { children: ReactNode }) => {
   const { themeElementRef } = useTheme()
 
   // Store the class list of the theme container as a string
-  const [classListString, setClassListString] = useState('')
+  const [classListString, setClassListString] = useState<string>('')
 
   // Watch for classList changes using MutationObserver
   useEffect(() => {

--- a/packages/app/src/contexts/ThemeValues/index.tsx
+++ b/packages/app/src/contexts/ThemeValues/index.tsx
@@ -1,0 +1,72 @@
+// Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useTheme } from 'contexts/Themes'
+import type { ReactNode } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
+import { defaultThemeValuesContext } from './defaults'
+import type { ThemeValuesContextInterface } from './types'
+
+export const ThemeValuesContext = createContext<ThemeValuesContextInterface>(
+  defaultThemeValuesContext
+)
+
+export const useThemeValues = () => useContext(ThemeValuesContext)
+
+export const ThemeValuesProvider = ({ children }: { children: ReactNode }) => {
+  const { themeElementRef } = useTheme()
+
+  // Store the class list of the theme container as a string
+  const [classListString, setClassListString] = useState('')
+
+  // Watch for classList changes using MutationObserver
+  useEffect(() => {
+    if (!themeElementRef.current) {
+      return
+    }
+    const observer = new MutationObserver(() => {
+      if (!themeElementRef.current) {
+        return
+      }
+      // Store classList as a string
+      setClassListString(themeElementRef.current.classList.toString())
+    })
+    observer.observe(themeElementRef.current, {
+      attributes: true,
+      attributeFilter: ['class'], // Only watch class changes
+    })
+    return () => observer.disconnect()
+  }, [])
+
+  // Get a CSS variable value from theme container
+  const getThemeValue = useCallback(
+    (variable: string) => {
+      if (!themeElementRef.current) {
+        return ''
+      }
+      const style = getComputedStyle(themeElementRef.current)
+      const value = style?.getPropertyValue(variable).trim()
+      return value
+    },
+    [classListString]
+  )
+
+  return (
+    <ThemeValuesContext.Provider
+      value={{
+        getThemeValue,
+      }}
+    >
+      {children}
+    </ThemeValuesContext.Provider>
+  )
+}

--- a/packages/app/src/contexts/ThemeValues/types.ts
+++ b/packages/app/src/contexts/ThemeValues/types.ts
@@ -1,0 +1,6 @@
+// Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+export interface ThemeValuesContextInterface {
+  getThemeValue: (name: string) => string
+}

--- a/packages/app/src/contexts/Themes/defaults.ts
+++ b/packages/app/src/contexts/Themes/defaults.ts
@@ -5,8 +5,7 @@
 import type { ThemeContextInterface } from './types'
 
 export const defaultThemeContext: ThemeContextInterface = {
-  toggleTheme: (str) => {},
   themeElementRef: { current: null },
+  toggleTheme: (str) => {},
   mode: 'light',
-  getThemeValue: (name) => '',
 }

--- a/packages/app/src/contexts/Themes/defaults.ts
+++ b/packages/app/src/contexts/Themes/defaults.ts
@@ -6,5 +6,7 @@ import type { ThemeContextInterface } from './types'
 
 export const defaultThemeContext: ThemeContextInterface = {
   toggleTheme: (str) => {},
+  themeElementRef: { current: null },
   mode: 'light',
+  getThemeValue: (name) => '',
 }

--- a/packages/app/src/contexts/Themes/index.tsx
+++ b/packages/app/src/contexts/Themes/index.tsx
@@ -3,7 +3,7 @@
 
 import { setStateWithRef } from '@w3ux/utils'
 import type { ReactNode } from 'react'
-import { createContext, useCallback, useContext, useRef, useState } from 'react'
+import { createContext, useContext, useRef, useState } from 'react'
 import { defaultThemeContext } from './defaults'
 import type { Theme, ThemeContextInterface } from './types'
 
@@ -57,25 +57,11 @@ export const ThemesProvider = ({ children }: { children: ReactNode }) => {
   // A ref to refer to the Entry component that stores the theme variables.
   const themeElementRef = useRef<HTMLDivElement>(null)
 
-  // Get a CSS variable value from theme container
-  const getThemeValue = useCallback(
-    (variable: string) => {
-      if (!themeElementRef.current) {
-        return ''
-      }
-      const style = getComputedStyle(themeElementRef.current)
-      const value = style?.getPropertyValue(variable).trim()
-      return value
-    },
-    [theme]
-  )
-
   return (
     <ThemeContext.Provider
       value={{
         toggleTheme,
         themeElementRef,
-        getThemeValue,
         mode: themeRef.current,
       }}
     >

--- a/packages/app/src/contexts/Themes/index.tsx
+++ b/packages/app/src/contexts/Themes/index.tsx
@@ -3,7 +3,7 @@
 
 import { setStateWithRef } from '@w3ux/utils'
 import type { ReactNode } from 'react'
-import { createContext, useContext, useRef, useState } from 'react'
+import { createContext, useCallback, useContext, useRef, useState } from 'react'
 import { defaultThemeContext } from './defaults'
 import type { Theme, ThemeContextInterface } from './types'
 
@@ -58,14 +58,17 @@ export const ThemesProvider = ({ children }: { children: ReactNode }) => {
   const themeElementRef = useRef<HTMLDivElement>(null)
 
   // Get a CSS variable value from theme container
-  const getThemeValue = (variable: string) => {
-    if (!themeElementRef.current) {
-      return ''
-    }
-    const style = getComputedStyle(themeElementRef.current)
-    const value = style?.getPropertyValue(variable)
-    return value
-  }
+  const getThemeValue = useCallback(
+    (variable: string) => {
+      if (!themeElementRef.current) {
+        return ''
+      }
+      const style = getComputedStyle(themeElementRef.current)
+      const value = style?.getPropertyValue(variable).trim()
+      return value
+    },
+    [theme]
+  )
 
   return (
     <ThemeContext.Provider

--- a/packages/app/src/contexts/Themes/index.tsx
+++ b/packages/app/src/contexts/Themes/index.tsx
@@ -54,10 +54,25 @@ export const ThemesProvider = ({ children }: { children: ReactNode }) => {
     setStateWithRef(newTheme, setTheme, themeRef)
   }
 
+  // A ref to refer to the Entry component that stores the theme variables.
+  const themeElementRef = useRef<HTMLDivElement>(null)
+
+  // Get a CSS variable value from theme container
+  const getThemeValue = (variable: string) => {
+    if (!themeElementRef.current) {
+      return ''
+    }
+    const style = getComputedStyle(themeElementRef.current)
+    const value = style?.getPropertyValue(variable)
+    return value
+  }
+
   return (
     <ThemeContext.Provider
       value={{
         toggleTheme,
+        themeElementRef,
+        getThemeValue,
         mode: themeRef.current,
       }}
     >

--- a/packages/app/src/contexts/Themes/types.ts
+++ b/packages/app/src/contexts/Themes/types.ts
@@ -6,8 +6,7 @@ import type { MutableRefObject } from 'react'
 export type Theme = 'light' | 'dark'
 
 export interface ThemeContextInterface {
-  toggleTheme: (str?: Theme) => void
   themeElementRef: MutableRefObject<HTMLDivElement | null>
+  toggleTheme: (str?: Theme) => void
   mode: Theme
-  getThemeValue: (name: string) => string
 }

--- a/packages/app/src/contexts/Themes/types.ts
+++ b/packages/app/src/contexts/Themes/types.ts
@@ -1,9 +1,13 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { MutableRefObject } from 'react'
+
 export type Theme = 'light' | 'dark'
 
 export interface ThemeContextInterface {
   toggleTheme: (str?: Theme) => void
+  themeElementRef: MutableRefObject<HTMLDivElement | null>
   mode: Theme
+  getThemeValue: (name: string) => string
 }

--- a/packages/app/src/library/Graphs/AveragePayoutLine.tsx
+++ b/packages/app/src/library/Graphs/AveragePayoutLine.tsx
@@ -15,6 +15,7 @@ import {
 } from 'chart.js'
 import { useNetwork } from 'contexts/Network'
 import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { Line } from 'react-chartjs-2'
 import { useTranslation } from 'react-i18next'
 import graphColors from 'styles/graphs/index.json'
@@ -45,7 +46,8 @@ export const AveragePayoutLine = ({
   inPool,
 }: AveragePayoutLineProps) => {
   const { t } = useTranslation('library')
-  const { mode, getThemeValue } = useTheme()
+  const { mode } = useTheme()
+  const { getThemeValue } = useThemeValues()
   const { unit, units } = useNetwork().networkData
 
   const staking = nominating || inPool

--- a/packages/app/src/library/Graphs/AveragePayoutLine.tsx
+++ b/packages/app/src/library/Graphs/AveragePayoutLine.tsx
@@ -45,8 +45,8 @@ export const AveragePayoutLine = ({
   inPool,
 }: AveragePayoutLineProps) => {
   const { t } = useTranslation('library')
-  const { mode } = useTheme()
-  const { unit, units, colors } = useNetwork().networkData
+  const { mode, getThemeValue } = useTheme()
+  const { unit, units } = useNetwork().networkData
 
   const staking = nominating || inPool
   const inPoolOnly = !nominating && inPool
@@ -77,10 +77,10 @@ export const AveragePayoutLine = ({
 
   // Determine color for payouts
   const color = !staking
-    ? colors.primary[mode]
+    ? getThemeValue('--accent-color-primary')
     : !inPoolOnly
-      ? colors.primary[mode]
-      : colors.secondary[mode]
+      ? getThemeValue('--accent-color-primary')
+      : getThemeValue('--accent-color-secondary')
 
   const options = {
     responsive: true,

--- a/packages/app/src/library/Graphs/EraPointsLine.tsx
+++ b/packages/app/src/library/Graphs/EraPointsLine.tsx
@@ -16,6 +16,7 @@ import {
   Tooltip,
 } from 'chart.js'
 import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { format, fromUnixTime } from 'date-fns'
 import { DefaultLocale, locales } from 'locales'
 import type { ValidatorEraPoints } from 'plugin-staking-api/types'
@@ -47,7 +48,8 @@ export const EraPointsLine = ({
   height: string | number
 }) => {
   const { i18n, t } = useTranslation()
-  const { mode, getThemeValue } = useTheme()
+  const { mode } = useTheme()
+  const { getThemeValue } = useThemeValues()
 
   // Format reward points as an array of strings, or an empty array if syncing
   const dataset = syncing

--- a/packages/app/src/library/Graphs/EraPointsLine.tsx
+++ b/packages/app/src/library/Graphs/EraPointsLine.tsx
@@ -15,7 +15,6 @@ import {
   Title,
   Tooltip,
 } from 'chart.js'
-import { useNetwork } from 'contexts/Network'
 import { useTheme } from 'contexts/Themes'
 import { format, fromUnixTime } from 'date-fns'
 import { DefaultLocale, locales } from 'locales'
@@ -48,8 +47,7 @@ export const EraPointsLine = ({
   height: string | number
 }) => {
   const { i18n, t } = useTranslation()
-  const { mode } = useTheme()
-  const { colors } = useNetwork().networkData
+  const { mode, getThemeValue } = useTheme()
 
   // Format reward points as an array of strings, or an empty array if syncing
   const dataset = syncing
@@ -57,8 +55,7 @@ export const EraPointsLine = ({
     : entries.map((entry) => new BigNumber(entry.points).toString())
 
   // Use primary color for line
-  const color = colors.primary[mode]
-
+  const color = getThemeValue('--accent-color-primary ')
   // Styling of axis titles
   const titleFontSpec: Partial<FontSpec> = {
     family: "'Inter', 'sans-serif'",

--- a/packages/app/src/library/Graphs/GeoDonut.tsx
+++ b/packages/app/src/library/Graphs/GeoDonut.tsx
@@ -6,6 +6,7 @@ import { ellipsisFn } from '@w3ux/utils'
 import { ArcElement, Chart as ChartJS, Legend, Tooltip } from 'chart.js'
 import chroma from 'chroma-js'
 import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { Doughnut } from 'react-chartjs-2'
 import graphColors from 'styles/graphs/index.json'
 import type { GeoDonutProps } from './types'
@@ -20,7 +21,8 @@ export const GeoDonut = ({
   legendHeight = 25,
   maxLabelLen = 3,
 }: GeoDonutProps) => {
-  const { mode, getThemeValue } = useTheme()
+  const { mode } = useTheme()
+  const { getThemeValue } = useThemeValues()
 
   const { labels } = series
   let { data } = series

--- a/packages/app/src/library/Graphs/GeoDonut.tsx
+++ b/packages/app/src/library/Graphs/GeoDonut.tsx
@@ -5,7 +5,6 @@ import type { AnyJson } from '@w3ux/types'
 import { ellipsisFn } from '@w3ux/utils'
 import { ArcElement, Chart as ChartJS, Legend, Tooltip } from 'chart.js'
 import chroma from 'chroma-js'
-import { useNetwork } from 'contexts/Network'
 import { useTheme } from 'contexts/Themes'
 import { Doughnut } from 'react-chartjs-2'
 import graphColors from 'styles/graphs/index.json'
@@ -21,15 +20,14 @@ export const GeoDonut = ({
   legendHeight = 25,
   maxLabelLen = 3,
 }: GeoDonutProps) => {
-  const { mode } = useTheme()
-  const { colors } = useNetwork().networkData
+  const { mode, getThemeValue } = useTheme()
 
   const { labels } = series
   let { data } = series
   const isZero = data.length === 0
   const backgroundColor = isZero
     ? graphColors.inactive[mode]
-    : colors.primary[mode]
+    : getThemeValue('--accent-color-primary')
 
   const total = data.reduce((acc: number, value: number) => acc + value, 0)
 

--- a/packages/app/src/library/Graphs/PayoutBar.tsx
+++ b/packages/app/src/library/Graphs/PayoutBar.tsx
@@ -16,6 +16,7 @@ import {
 } from 'chart.js'
 import { useNetwork } from 'contexts/Network'
 import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { format, fromUnixTime } from 'date-fns'
 import { DefaultLocale, locales } from 'locales'
 import { Bar } from 'react-chartjs-2'
@@ -45,7 +46,8 @@ export const PayoutBar = ({
   syncing,
 }: PayoutBarProps) => {
   const { i18n, t } = useTranslation('library')
-  const { mode, getThemeValue } = useTheme()
+  const { mode } = useTheme()
+  const { getThemeValue } = useThemeValues()
   const { unit, units } = useNetwork().networkData
   const staking = nominating || inPool
 

--- a/packages/app/src/library/Graphs/PayoutBar.tsx
+++ b/packages/app/src/library/Graphs/PayoutBar.tsx
@@ -45,8 +45,8 @@ export const PayoutBar = ({
   syncing,
 }: PayoutBarProps) => {
   const { i18n, t } = useTranslation('library')
-  const { mode } = useTheme()
-  const { unit, units, colors } = useNetwork().networkData
+  const { mode, getThemeValue } = useTheme()
+  const { unit, units } = useNetwork().networkData
   const staking = nominating || inPool
 
   // Get formatted rewards data
@@ -65,13 +65,13 @@ export const PayoutBar = ({
 
   // Determine color for payouts
   const colorPayouts = !staking
-    ? colors.transparent[mode]
-    : colors.primary[mode]
+    ? getThemeValue('--accent-color-transparent')
+    : getThemeValue('--accent-color-primary')
 
   // Determine color for poolClaims
   const colorPoolClaims = !staking
-    ? colors.transparent[mode]
-    : colors.secondary[mode]
+    ? getThemeValue('--accent-color-transparent')
+    : getThemeValue('--accent-color-secondary')
 
   const borderRadius = 4
   const pointRadius = 0
@@ -109,7 +109,7 @@ export const PayoutBar = ({
         ),
         label: t('unclaimedPayouts'),
         borderColor: colorPayouts,
-        backgroundColor: colors.pending[mode],
+        backgroundColor: getThemeValue('--accent-color-pending'),
         pointRadius,
         borderRadius,
       },

--- a/packages/app/src/library/Graphs/PayoutLine.tsx
+++ b/packages/app/src/library/Graphs/PayoutLine.tsx
@@ -17,6 +17,7 @@ import {
 } from 'chart.js'
 import { useNetwork } from 'contexts/Network'
 import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { format, fromUnixTime } from 'date-fns'
 import { DefaultLocale, locales } from 'locales'
 import { Line } from 'react-chartjs-2'
@@ -48,8 +49,9 @@ export const PayoutLine = ({
   height: string | number
 }) => {
   const { i18n, t } = useTranslation()
-  const { mode, getThemeValue } = useTheme()
+  const { mode } = useTheme()
   const { unit } = useNetwork().networkData
+  const { getThemeValue } = useThemeValues()
 
   // Format reward points as an array of strings, or an empty array if syncing
   const dataset = syncing

--- a/packages/app/src/library/Graphs/PayoutLine.tsx
+++ b/packages/app/src/library/Graphs/PayoutLine.tsx
@@ -48,8 +48,8 @@ export const PayoutLine = ({
   height: string | number
 }) => {
   const { i18n, t } = useTranslation()
-  const { mode } = useTheme()
-  const { colors, unit } = useNetwork().networkData
+  const { mode, getThemeValue } = useTheme()
+  const { unit } = useNetwork().networkData
 
   // Format reward points as an array of strings, or an empty array if syncing
   const dataset = syncing
@@ -57,7 +57,7 @@ export const PayoutLine = ({
     : entries.map((entry) => new BigNumber(entry.reward).toString())
 
   // Use primary color for line
-  const color = colors.primary[mode]
+  const color = getThemeValue('--accent-color-primary')
 
   // Styling of axis titles
   const titleFontSpec: Partial<FontSpec> = {

--- a/packages/app/src/library/PoolList/index.tsx
+++ b/packages/app/src/library/PoolList/index.tsx
@@ -9,7 +9,7 @@ import { useFilters } from 'contexts/Filters'
 import { useList } from 'contexts/List'
 import { useNetwork } from 'contexts/Network'
 import { useBondedPools } from 'contexts/Pools/BondedPools'
-import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { motion } from 'framer-motion'
 import { usePoolFilters } from 'hooks/usePoolFilters'
 import { useSyncing } from 'hooks/useSyncing'
@@ -41,8 +41,8 @@ export const PoolList = ({
   const { activeEra } = useApi()
   const { syncing } = useSyncing()
   const { network } = useNetwork()
-  const { getThemeValue } = useTheme()
   const { applyFilter } = usePoolFilters()
+  const { getThemeValue } = useThemeValues()
   const { listFormat, setListFormat } = useList()
   const { poolSearchFilter, poolsNominations } = useBondedPools()
   const { getFilters, getSearchTerm, setSearchTerm } = useFilters()

--- a/packages/app/src/library/PoolList/index.tsx
+++ b/packages/app/src/library/PoolList/index.tsx
@@ -38,13 +38,10 @@ export const PoolList = ({
   itemsPerPage,
 }: PoolListProps) => {
   const { t } = useTranslation('library')
-  const {
-    network,
-    networkData: { colors },
-  } = useNetwork()
-  const { mode } = useTheme()
   const { activeEra } = useApi()
   const { syncing } = useSyncing()
+  const { network } = useNetwork()
+  const { getThemeValue } = useTheme()
   const { applyFilter } = usePoolFilters()
   const { listFormat, setListFormat } = useList()
   const { poolSearchFilter, poolsNominations } = useBondedPools()
@@ -185,7 +182,9 @@ export const PoolList = ({
                   <FontAwesomeIcon
                     icon={faBars}
                     color={
-                      listFormat === 'row' ? colors.primary[mode] : 'inherit'
+                      listFormat === 'row'
+                        ? getThemeValue('--accent-color-primary')
+                        : 'inherit'
                     }
                   />
                 </button>
@@ -193,7 +192,9 @@ export const PoolList = ({
                   <FontAwesomeIcon
                     icon={faGripVertical}
                     color={
-                      listFormat === 'col' ? colors.primary[mode] : 'inherit'
+                      listFormat === 'col'
+                        ? getThemeValue('--accent-color-primary')
+                        : 'inherit'
                     }
                   />
                 </button>

--- a/packages/app/src/library/ValidatorList/index.tsx
+++ b/packages/app/src/library/ValidatorList/index.tsx
@@ -53,9 +53,6 @@ export const ValidatorListInner = ({
 }: ValidatorListProps) => {
   const { t } = useTranslation()
   const {
-    networkData: { colors },
-  } = useNetwork()
-  const {
     getFilters,
     setMultiFilters,
     getOrder,
@@ -67,10 +64,10 @@ export const ValidatorListInner = ({
     clearSearchTerm,
     // Inject default filters and orders here
   } = useFilters()
-  const { mode } = useTheme()
   const listProvider = useList()
   const { syncing } = useSyncing()
   const { network } = useNetwork()
+  const { getThemeValue } = useTheme()
   const { pluginEnabled } = usePlugins()
   const { activeAccount } = useActiveAccounts()
   const { setModalResize } = useOverlay().modal
@@ -318,7 +315,9 @@ export const ValidatorListInner = ({
                   <FontAwesomeIcon
                     icon={faBars}
                     color={
-                      listFormat === 'row' ? colors.primary[mode] : 'inherit'
+                      listFormat === 'row'
+                        ? getThemeValue('--accent-color-primary')
+                        : 'inherit'
                     }
                   />
                 </button>
@@ -326,7 +325,9 @@ export const ValidatorListInner = ({
                   <FontAwesomeIcon
                     icon={faGripVertical}
                     color={
-                      listFormat === 'col' ? colors.primary[mode] : 'inherit'
+                      listFormat === 'col'
+                        ? getThemeValue('--accent-color-primary')
+                        : 'inherit'
                     }
                   />
                 </button>

--- a/packages/app/src/library/ValidatorList/index.tsx
+++ b/packages/app/src/library/ValidatorList/index.tsx
@@ -9,7 +9,7 @@ import { useFilters } from 'contexts/Filters'
 import { ListProvider, useList } from 'contexts/List'
 import { useNetwork } from 'contexts/Network'
 import { usePlugins } from 'contexts/Plugins'
-import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import type { Validator, ValidatorListEntry } from 'contexts/Validators/types'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { motion } from 'framer-motion'
@@ -67,8 +67,8 @@ export const ValidatorListInner = ({
   const listProvider = useList()
   const { syncing } = useSyncing()
   const { network } = useNetwork()
-  const { getThemeValue } = useTheme()
   const { pluginEnabled } = usePlugins()
+  const { getThemeValue } = useThemeValues()
   const { activeAccount } = useActiveAccounts()
   const { setModalResize } = useOverlay().modal
   const { injectValidatorListData } = useValidators()

--- a/packages/app/src/library/WithdrawPrompt/index.tsx
+++ b/packages/app/src/library/WithdrawPrompt/index.tsx
@@ -5,7 +5,7 @@ import { faLockOpen } from '@fortawesome/free-solid-svg-icons'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useActivePool } from 'contexts/Pools/ActivePool'
-import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { useTransferOptions } from 'contexts/TransferOptions'
 import { getUnixTime } from 'date-fns'
 import { useErasToTimeLeft } from 'hooks/useErasToTimeLeft'
@@ -21,9 +21,9 @@ import { timeleftAsString } from 'utils'
 export const WithdrawPrompt = ({ bondFor }: { bondFor: BondFor }) => {
   const { t } = useTranslation('modals')
   const { consts } = useApi()
-  const { getThemeValue } = useTheme()
   const { activePool } = useActivePool()
   const { openModal } = useOverlay().modal
+  const { getThemeValue } = useThemeValues()
 
   const { syncing } = useSyncing(['balances'])
   const { activeAccount } = useActiveAccounts()

--- a/packages/app/src/library/WithdrawPrompt/index.tsx
+++ b/packages/app/src/library/WithdrawPrompt/index.tsx
@@ -4,7 +4,6 @@
 import { faLockOpen } from '@fortawesome/free-solid-svg-icons'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
-import { useNetwork } from 'contexts/Network'
 import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useTheme } from 'contexts/Themes'
 import { useTransferOptions } from 'contexts/TransferOptions'
@@ -21,11 +20,10 @@ import { timeleftAsString } from 'utils'
 
 export const WithdrawPrompt = ({ bondFor }: { bondFor: BondFor }) => {
   const { t } = useTranslation('modals')
-  const { mode } = useTheme()
   const { consts } = useApi()
+  const { getThemeValue } = useTheme()
   const { activePool } = useActivePool()
   const { openModal } = useOverlay().modal
-  const { colors } = useNetwork().networkData
 
   const { syncing } = useSyncing(['balances'])
   const { activeAccount } = useActiveAccounts()
@@ -57,7 +55,11 @@ export const WithdrawPrompt = ({ bondFor }: { bondFor: BondFor }) => {
     state !== 'Destroying' &&
     displayPrompt && (
       <PageRow>
-        <CardWrapper style={{ border: `1px solid ${colors.secondary[mode]}` }}>
+        <CardWrapper
+          style={{
+            border: `1px solid ${getThemeValue('--accent-color-primary')}`,
+          }}
+        >
           <div className="content">
             <h3>{t('unlocksInProgress')}</h3>
             <h4>{t('youHaveActiveUnlocks', { bondDurationFormatted })}</h4>

--- a/packages/app/src/overlay/canvas/PoolMembers/Members.tsx
+++ b/packages/app/src/overlay/canvas/PoolMembers/Members.tsx
@@ -4,14 +4,14 @@
 import { faBars } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useActivePool } from 'contexts/Pools/ActivePool'
-import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { CardWrapper } from 'library/Card/Wrappers'
 import { useTranslation } from 'react-i18next'
 import { MembersList as FetchPageMemberList } from './Lists/FetchPage'
 
 export const Members = () => {
   const { t } = useTranslation('pages')
-  const { getThemeValue } = useTheme()
+  const { getThemeValue } = useThemeValues()
   const { activePool, isOwner, isBouncer } = useActivePool()
 
   const annuncementBorderColor = getThemeValue('--accent-color-secondary')

--- a/packages/app/src/overlay/canvas/PoolMembers/Members.tsx
+++ b/packages/app/src/overlay/canvas/PoolMembers/Members.tsx
@@ -3,7 +3,6 @@
 
 import { faBars } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { useNetwork } from 'contexts/Network'
 import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useTheme } from 'contexts/Themes'
 import { CardWrapper } from 'library/Card/Wrappers'
@@ -12,11 +11,10 @@ import { MembersList as FetchPageMemberList } from './Lists/FetchPage'
 
 export const Members = () => {
   const { t } = useTranslation('pages')
-  const { mode } = useTheme()
+  const { getThemeValue } = useTheme()
   const { activePool, isOwner, isBouncer } = useActivePool()
 
-  const { colors } = useNetwork().networkData
-  const annuncementBorderColor = colors.secondary[mode]
+  const annuncementBorderColor = getThemeValue('--accent-color-secondary')
 
   const showBlockedPrompt =
     activePool?.bondedPool?.state === 'Blocked' && (isOwner() || isBouncer())

--- a/packages/app/src/pages/Nominate/Active/CommissionPrompt.tsx
+++ b/packages/app/src/pages/Nominate/Active/CommissionPrompt.tsx
@@ -8,7 +8,6 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useBalances } from 'contexts/Balances'
-import { useNetwork } from 'contexts/Network'
 import { useStaking } from 'contexts/Staking'
 import { useTheme } from 'contexts/Themes'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
@@ -21,12 +20,11 @@ import { useOverlay } from 'ui-overlay'
 
 export const CommissionPrompt = () => {
   const { t } = useTranslation('pages')
-  const { mode } = useTheme()
   const { inSetup } = useStaking()
   const { getNominations } = useBalances()
+  const { getThemeValue } = useTheme()
   const { openCanvas } = useOverlay().canvas
   const { formatWithPrefs } = useValidators()
-  const { colors } = useNetwork().networkData
   const { activeAccount } = useActiveAccounts()
   const { syncing } = useSyncing(['active-pools'])
 
@@ -39,7 +37,7 @@ export const CommissionPrompt = () => {
     return null
   }
 
-  const annuncementBorderColor = colors.secondary[mode]
+  const annuncementBorderColor = getThemeValue('--accent-color-secondary')
 
   return (
     <PageRow>

--- a/packages/app/src/pages/Nominate/Active/CommissionPrompt.tsx
+++ b/packages/app/src/pages/Nominate/Active/CommissionPrompt.tsx
@@ -9,7 +9,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useBalances } from 'contexts/Balances'
 import { useStaking } from 'contexts/Staking'
-import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useSyncing } from 'hooks/useSyncing'
 import { CardWrapper } from 'library/Card/Wrappers'
@@ -22,8 +22,8 @@ export const CommissionPrompt = () => {
   const { t } = useTranslation('pages')
   const { inSetup } = useStaking()
   const { getNominations } = useBalances()
-  const { getThemeValue } = useTheme()
   const { openCanvas } = useOverlay().canvas
+  const { getThemeValue } = useThemeValues()
   const { formatWithPrefs } = useValidators()
   const { activeAccount } = useActiveAccounts()
   const { syncing } = useSyncing(['active-pools'])

--- a/packages/app/src/pages/Nominate/Active/UnstakePrompts.tsx
+++ b/packages/app/src/pages/Nominate/Active/UnstakePrompts.tsx
@@ -17,18 +17,17 @@ import { useOverlay } from 'ui-overlay'
 
 export const UnstakePrompts = () => {
   const { t } = useTranslation('pages')
-  const { mode } = useTheme()
   const { syncing } = useSyncing()
   const { inSetup } = useStaking()
+  const { getThemeValue } = useTheme()
   const { openModal } = useOverlay().modal
+  const { unit } = useNetwork().networkData
   const { activeAccount } = useActiveAccounts()
-  const { unit, colors } = useNetwork().networkData
   const { isFastUnstaking, isUnstaking, getFastUnstakeText } = useUnstaking()
 
   const { getTransferOptions } = useTransferOptions()
   const { active, totalUnlockChunks, totalUnlocked, totalUnlocking } =
     getTransferOptions(activeAccount).nominate
-  const annuncementBorderColor = colors.secondary[mode]
 
   // unstaking can withdraw
   const canWithdrawUnlocks =
@@ -42,7 +41,11 @@ export const UnstakePrompts = () => {
     (isUnstaking || isFastUnstaking) &&
     !syncing && (
       <PageRow>
-        <CardWrapper style={{ border: `1px solid ${annuncementBorderColor}` }}>
+        <CardWrapper
+          style={{
+            border: `1px solid ${getThemeValue('--accent-color-secondary')}`,
+          }}
+        >
           <div className="content">
             <h3>
               {t('nominate.unstakePromptInProgress', {

--- a/packages/app/src/pages/Nominate/Active/UnstakePrompts.tsx
+++ b/packages/app/src/pages/Nominate/Active/UnstakePrompts.tsx
@@ -5,7 +5,7 @@ import { faBolt, faLockOpen } from '@fortawesome/free-solid-svg-icons'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useNetwork } from 'contexts/Network'
 import { useStaking } from 'contexts/Staking'
-import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { useTransferOptions } from 'contexts/TransferOptions'
 import { useSyncing } from 'hooks/useSyncing'
 import { useUnstaking } from 'hooks/useUnstaking'
@@ -19,9 +19,9 @@ export const UnstakePrompts = () => {
   const { t } = useTranslation('pages')
   const { syncing } = useSyncing()
   const { inSetup } = useStaking()
-  const { getThemeValue } = useTheme()
   const { openModal } = useOverlay().modal
   const { unit } = useNetwork().networkData
+  const { getThemeValue } = useThemeValues()
   const { activeAccount } = useActiveAccounts()
   const { isFastUnstaking, isUnstaking, getFastUnstakeText } = useUnstaking()
 

--- a/packages/app/src/pages/Payouts/PayoutList/index.tsx
+++ b/packages/app/src/pages/Payouts/PayoutList/index.tsx
@@ -40,10 +40,10 @@ export const PayoutListInner = ({
   itemsPerPage,
 }: PayoutListProps) => {
   const { i18n, t } = useTranslation('pages')
-  const { mode } = useTheme()
+  const { getThemeValue } = useTheme()
   const { isReady, activeEra } = useApi()
   const {
-    networkData: { units, unit, colors },
+    networkData: { units, unit },
   } = useNetwork()
   const { bondedPools } = useBondedPools()
   const { getValidators } = useValidators()
@@ -89,13 +89,21 @@ export const PayoutListInner = ({
           <button type="button" onClick={() => setListFormat('row')}>
             <FontAwesomeIcon
               icon={faBars}
-              color={listFormat === 'row' ? colors.primary[mode] : 'inherit'}
+              color={
+                listFormat === 'row'
+                  ? getThemeValue('--accent-color-primary')
+                  : 'inherit'
+              }
             />
           </button>
           <button type="button" onClick={() => setListFormat('col')}>
             <FontAwesomeIcon
               icon={faGripVertical}
-              color={listFormat === 'col' ? colors.primary[mode] : 'inherit'}
+              color={
+                listFormat === 'col'
+                  ? getThemeValue('--accent-color-primary')
+                  : 'inherit'
+              }
             />
           </button>
         </div>

--- a/packages/app/src/pages/Payouts/PayoutList/index.tsx
+++ b/packages/app/src/pages/Payouts/PayoutList/index.tsx
@@ -9,7 +9,7 @@ import { useApi } from 'contexts/Api'
 import { ListProvider, useList } from 'contexts/List'
 import { useNetwork } from 'contexts/Network'
 import { useBondedPools } from 'contexts/Pools/BondedPools'
-import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { formatDistance, fromUnixTime } from 'date-fns'
 import { motion } from 'framer-motion'
@@ -40,13 +40,13 @@ export const PayoutListInner = ({
   itemsPerPage,
 }: PayoutListProps) => {
   const { i18n, t } = useTranslation('pages')
-  const { getThemeValue } = useTheme()
   const { isReady, activeEra } = useApi()
   const {
     networkData: { units, unit },
   } = useNetwork()
   const { bondedPools } = useBondedPools()
   const { getValidators } = useValidators()
+  const { getThemeValue } = useThemeValues()
   const { listFormat, setListFormat } = useList()
 
   const [page, setPage] = useState<number>(1)

--- a/packages/app/src/pages/Pools/ClosurePrompts.tsx
+++ b/packages/app/src/pages/Pools/ClosurePrompts.tsx
@@ -3,7 +3,6 @@
 
 import { faLockOpen } from '@fortawesome/free-solid-svg-icons'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
-import { useNetwork } from 'contexts/Network'
 import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useTheme } from 'contexts/Themes'
 import { useTransferOptions } from 'contexts/TransferOptions'
@@ -16,9 +15,8 @@ import { useOverlay } from 'ui-overlay'
 
 export const ClosurePrompts = () => {
   const { t } = useTranslation('pages')
-  const { mode } = useTheme()
+  const { getThemeValue } = useTheme()
   const { openModal } = useOverlay().modal
-  const { colors } = useNetwork().networkData
   const { activeAccount } = useActiveAccounts()
   const { syncing } = useSyncing(['active-pools'])
   const { getTransferOptions } = useTransferOptions()
@@ -28,7 +26,6 @@ export const ClosurePrompts = () => {
   const { state, memberCounter } = activePool?.bondedPool || {}
   const { active, totalUnlockChunks } = getTransferOptions(activeAccount).pool
   const targets = activePoolNominations?.targets ?? []
-  const annuncementBorderColor = colors.secondary[mode]
 
   // is the pool in a state for the depositor to close
   const depositorCanClose =
@@ -45,7 +42,11 @@ export const ClosurePrompts = () => {
     state === 'Destroying' &&
     depositorCanClose && (
       <PageRow>
-        <CardWrapper style={{ border: `1px solid ${annuncementBorderColor}` }}>
+        <CardWrapper
+          style={{
+            border: `1px solid ${getThemeValue('--accent-color-secondary')}`,
+          }}
+        >
           <div className="content">
             <h3>{t('pools.destroyPool')}</h3>
             <h4>

--- a/packages/app/src/pages/Pools/ClosurePrompts.tsx
+++ b/packages/app/src/pages/Pools/ClosurePrompts.tsx
@@ -4,7 +4,7 @@
 import { faLockOpen } from '@fortawesome/free-solid-svg-icons'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useActivePool } from 'contexts/Pools/ActivePool'
-import { useTheme } from 'contexts/Themes'
+import { useThemeValues } from 'contexts/ThemeValues'
 import { useTransferOptions } from 'contexts/TransferOptions'
 import { useSyncing } from 'hooks/useSyncing'
 import { CardWrapper } from 'library/Card/Wrappers'
@@ -15,8 +15,8 @@ import { useOverlay } from 'ui-overlay'
 
 export const ClosurePrompts = () => {
   const { t } = useTranslation('pages')
-  const { getThemeValue } = useTheme()
   const { openModal } = useOverlay().modal
+  const { getThemeValue } = useThemeValues()
   const { activeAccount } = useActiveAccounts()
   const { syncing } = useSyncing(['active-pools'])
   const { getTransferOptions } = useTransferOptions()

--- a/packages/styles/accents/kusama.scss
+++ b/packages/styles/accents/kusama.scss
@@ -5,7 +5,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   $base-primary: rgb(51, 51, 53);
   $base-secondary: rgb(141 144 150);
 
-  @for $i from 1 through 19 {
+  @for $i from 0 through 19 {
     --accent-color-primary-#{100 - ($i * 5)}: #{hsl(
         hue($base-primary),
         saturation($base-primary),
@@ -18,10 +18,10 @@ SPDX-License-Identifier: GPL-3.0-only */
       )};
   }
 
-  --accent-color-primary-light: #{$base-primary};
-  --accent-color-primary-dark: var(--accent-color-primary-55);
+  --accent-color-primary-light: var(--accent-color-primary-90);
+  --accent-color-primary-dark: var(--accent-color-primary-50);
 
-  --accent-color-secondary-light: #{$base-secondary};
+  --accent-color-secondary-light: var(--accent-color-secondary-50);
   --accent-color-secondary-dark: var(--accent-color-secondary-55);
 
   --accent-color-tertiary-light: rgb(230, 230, 230);

--- a/packages/styles/accents/kusama.scss
+++ b/packages/styles/accents/kusama.scss
@@ -2,11 +2,8 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 .theme-kusama-relay {
-  $base-primary: rgb(126 131 141);
+  $base-primary: rgb(51, 51, 53);
   $base-secondary: rgb(141 144 150);
-
-  --accent-color-primary-default: #{$base-primary};
-  --accent-color-secondary-default: #{$base-secondary};
 
   @for $i from 1 through 19 {
     --accent-color-primary-#{100 - ($i * 5)}: #{hsl(
@@ -20,6 +17,12 @@ SPDX-License-Identifier: GPL-3.0-only */
         $i * 5%
       )};
   }
+
+  --accent-color-primary-light: #{$base-primary};
+  --accent-color-primary-dark: var(--accent-color-primary-55);
+
+  --accent-color-secondary-light: #{$base-secondary};
+  --accent-color-secondary-dark: var(--accent-color-secondary-55);
 
   --accent-color-tertiary-light: rgb(230, 230, 230);
   --accent-color-tertiary-dark: rgb(68, 68, 68);

--- a/packages/styles/accents/kusama.scss
+++ b/packages/styles/accents/kusama.scss
@@ -5,8 +5,8 @@ SPDX-License-Identifier: GPL-3.0-only */
   $base-primary: rgb(126 131 141);
   $base-secondary: rgb(141 144 150);
 
-  --accent-color-primary: #{$base-primary};
-  --accent-color-secondary: #{$base-secondary};
+  --accent-color-primary-default: #{$base-primary};
+  --accent-color-secondary-default: #{$base-secondary};
 
   @for $i from 1 through 19 {
     --accent-color-primary-#{100 - ($i * 5)}: #{hsl(

--- a/packages/styles/accents/polkadot.scss
+++ b/packages/styles/accents/polkadot.scss
@@ -5,7 +5,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   $base-primary: rgb(211, 48, 121);
   $base-secondary: rgb(110, 71, 207);
 
-  @for $i from 1 through 19 {
+  @for $i from 0 through 19 {
     --accent-color-primary-#{100 - ($i * 5)}: #{hsl(
         hue($base-primary),
         saturation($base-primary),
@@ -18,7 +18,7 @@ SPDX-License-Identifier: GPL-3.0-only */
       )};
   }
 
-  --accent-color-primary-light: #{$base-primary};
+  --accent-color-primary-light: var(--accent-color-primary-50);
   --accent-color-primary-dark: var(--accent-color-primary-40);
 
   --accent-color-secondary-light: #{$base-secondary};

--- a/packages/styles/accents/polkadot.scss
+++ b/packages/styles/accents/polkadot.scss
@@ -21,7 +21,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   --accent-color-primary-light: var(--accent-color-primary-50);
   --accent-color-primary-dark: var(--accent-color-primary-40);
 
-  --accent-color-secondary-light: #{$base-secondary};
+  --accent-color-secondary-light: var(--accent-color-secondary-50);
   --accent-color-secondary-dark: var(--accent-color-secondary-40);
 
   --accent-color-tertiary-light: rgb(221, 217, 231);

--- a/packages/styles/accents/polkadot.scss
+++ b/packages/styles/accents/polkadot.scss
@@ -5,9 +5,6 @@ SPDX-License-Identifier: GPL-3.0-only */
   $base-primary: rgb(211, 48, 121);
   $base-secondary: rgb(110, 71, 207);
 
-  --accent-color-primary-default: #{$base-primary};
-  --accent-color-secondary-default: #{$base-secondary};
-
   @for $i from 1 through 19 {
     --accent-color-primary-#{100 - ($i * 5)}: #{hsl(
         hue($base-primary),
@@ -20,6 +17,12 @@ SPDX-License-Identifier: GPL-3.0-only */
         $i * 5%
       )};
   }
+
+  --accent-color-primary-light: #{$base-primary};
+  --accent-color-primary-dark: var(--accent-color-primary-40);
+
+  --accent-color-secondary-light: #{$base-secondary};
+  --accent-color-secondary-dark: var(--accent-color-secondary-40);
 
   --accent-color-tertiary-light: rgb(221, 217, 231);
   --accent-color-tertiary-dark: rgb(50, 38, 76);

--- a/packages/styles/accents/polkadot.scss
+++ b/packages/styles/accents/polkadot.scss
@@ -5,8 +5,8 @@ SPDX-License-Identifier: GPL-3.0-only */
   $base-primary: rgb(211, 48, 121);
   $base-secondary: rgb(110, 71, 207);
 
-  --accent-color-primary: #{$base-primary};
-  --accent-color-secondary: #{$base-secondary};
+  --accent-color-primary-default: #{$base-primary};
+  --accent-color-secondary-default: #{$base-secondary};
 
   @for $i from 1 through 19 {
     --accent-color-primary-#{100 - ($i * 5)}: #{hsl(

--- a/packages/styles/accents/westend.scss
+++ b/packages/styles/accents/westend.scss
@@ -5,7 +5,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   $base-primary: rgb(218, 78, 113);
   $base-secondary: rgb(222, 106, 80);
 
-  @for $i from 1 through 19 {
+  @for $i from 0 through 19 {
     --accent-color-primary-#{100 - ($i * 5)}: #{hsl(
         hue($base-primary),
         saturation($base-primary),
@@ -18,11 +18,11 @@ SPDX-License-Identifier: GPL-3.0-only */
       )};
   }
 
-  --accent-color-primary-light: #{$base-primary};
-  --accent-color-primary-dark: #{$base-primary};
+  --accent-color-primary-light: var(--accent-color-primary-50);
+  --accent-color-primary-dark: var(--accent-color-primary-50);
 
-  --accent-color-secondary-light: #{$base-secondary};
-  --accent-color-secondary-dark: var(--accent-color-secondary-100);
+  --accent-color-secondary-light: var(--accent-color-secondary-50);
+  --accent-color-secondary-dark: var(--accent-color-secondary-50);
 
   --accent-color-tertiary-light: rgb(232, 213, 208);
   --accent-color-tertiary-dark: rgb(70, 48, 47);

--- a/packages/styles/accents/westend.scss
+++ b/packages/styles/accents/westend.scss
@@ -5,8 +5,8 @@ SPDX-License-Identifier: GPL-3.0-only */
   $base-primary: rgb(218, 78, 113);
   $base-secondary: rgb(222, 106, 80);
 
-  --accent-color-primary: #{$base-primary};
-  --accent-color-secondary: #{$base-secondary};
+  --accent-color-primary-default: #{$base-primary};
+  --accent-color-secondary-default: #{$base-secondary};
 
   @for $i from 1 through 19 {
     --accent-color-primary-#{100 - ($i * 5)}: #{hsl(

--- a/packages/styles/accents/westend.scss
+++ b/packages/styles/accents/westend.scss
@@ -5,9 +5,6 @@ SPDX-License-Identifier: GPL-3.0-only */
   $base-primary: rgb(218, 78, 113);
   $base-secondary: rgb(222, 106, 80);
 
-  --accent-color-primary-default: #{$base-primary};
-  --accent-color-secondary-default: #{$base-secondary};
-
   @for $i from 1 through 19 {
     --accent-color-primary-#{100 - ($i * 5)}: #{hsl(
         hue($base-primary),
@@ -20,6 +17,12 @@ SPDX-License-Identifier: GPL-3.0-only */
         $i * 5%
       )};
   }
+
+  --accent-color-primary-light: #{$base-primary};
+  --accent-color-primary-dark: #{$base-primary};
+
+  --accent-color-secondary-light: #{$base-secondary};
+  --accent-color-secondary-dark: var(--accent-color-secondary-100);
 
   --accent-color-tertiary-light: rgb(232, 213, 208);
   --accent-color-tertiary-dark: rgb(70, 48, 47);

--- a/packages/styles/theme/theme.scss
+++ b/packages/styles/theme/theme.scss
@@ -43,8 +43,8 @@ SPDX-License-Identifier: GPL-3.0-only */
   --card-shadow-color: rgb(158 158 158 / 20%);
   --card-deep-shadow-color: rgb(158 158 158 / 50%);
   --card-shadow-color-secondary: #e7e7e7;
-  --accent-color-primary: var(--accent-color-primary-default);
-  --accent-color-secondary: var(--accent-color-secondary-default);
+  --accent-color-primary: var(--accent-color-primary-light);
+  --accent-color-secondary: var(--accent-color-secondary-light);
   --accent-color-tertiary: var(--accent-color-tertiary-light);
   --accent-color-stroke: var(--accent-color-stroke-light);
   --accent-color-transparent: var(--accent-color-transparent-light);
@@ -120,8 +120,8 @@ SPDX-License-Identifier: GPL-3.0-only */
   --card-shadow-color: rgb(28 24 28 / 25%);
   --card-deep-shadow-color: rgb(28 24 28 / 50%);
   --card-shadow-color-secondary: rgb(28 24 28 / 25%);
-  --accent-color-primary: var(--accent-color-primary-default);
-  --accent-color-secondary: var(--accent-color-secondary-default);
+  --accent-color-primary: var(--accent-color-primary-dark);
+  --accent-color-secondary: var(--accent-color-secondary-dark);
   --accent-color-tertiary: var(--accent-color-tertiary-dark);
   --accent-color-stroke: var(--accent-color-stroke-dark);
   --accent-color-transparent: var(--accent-color-transparent-dark);

--- a/packages/styles/theme/theme.scss
+++ b/packages/styles/theme/theme.scss
@@ -43,6 +43,8 @@ SPDX-License-Identifier: GPL-3.0-only */
   --card-shadow-color: rgb(158 158 158 / 20%);
   --card-deep-shadow-color: rgb(158 158 158 / 50%);
   --card-shadow-color-secondary: #e7e7e7;
+  --accent-color-primary: var(--accent-color-primary-default);
+  --accent-color-secondary: var(--accent-color-primary-default);
   --accent-color-tertiary: var(--accent-color-tertiary-light);
   --accent-color-stroke: var(--accent-color-stroke-light);
   --accent-color-transparent: var(--accent-color-transparent-light);
@@ -118,6 +120,8 @@ SPDX-License-Identifier: GPL-3.0-only */
   --card-shadow-color: rgb(28 24 28 / 25%);
   --card-deep-shadow-color: rgb(28 24 28 / 50%);
   --card-shadow-color-secondary: rgb(28 24 28 / 25%);
+  --accent-color-primary: var(--accent-color-primary-default);
+  --accent-color-secondary: var(--accent-color-primary-default);
   --accent-color-tertiary: var(--accent-color-tertiary-dark);
   --accent-color-stroke: var(--accent-color-stroke-dark);
   --accent-color-transparent: var(--accent-color-transparent-dark);

--- a/packages/styles/theme/theme.scss
+++ b/packages/styles/theme/theme.scss
@@ -44,7 +44,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   --card-deep-shadow-color: rgb(158 158 158 / 50%);
   --card-shadow-color-secondary: #e7e7e7;
   --accent-color-primary: var(--accent-color-primary-default);
-  --accent-color-secondary: var(--accent-color-primary-default);
+  --accent-color-secondary: var(--accent-color-secondary-default);
   --accent-color-tertiary: var(--accent-color-tertiary-light);
   --accent-color-stroke: var(--accent-color-stroke-light);
   --accent-color-transparent: var(--accent-color-transparent-light);
@@ -121,7 +121,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   --card-deep-shadow-color: rgb(28 24 28 / 50%);
   --card-shadow-color-secondary: rgb(28 24 28 / 25%);
   --accent-color-primary: var(--accent-color-primary-default);
-  --accent-color-secondary: var(--accent-color-primary-default);
+  --accent-color-secondary: var(--accent-color-secondary-default);
   --accent-color-tertiary: var(--accent-color-tertiary-dark);
   --accent-color-stroke: var(--accent-color-stroke-dark);
   --accent-color-transparent: var(--accent-color-transparent-dark);

--- a/packages/ui-buttons/src/ButtonPrimaryInvert/index.module.scss
+++ b/packages/ui-buttons/src/ButtonPrimaryInvert/index.module.scss
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 .btnPrimaryInvert {
-  border: 1px solid var(--accent-color-stroke);
+  border: 1px solid var(--accent-color-primary);
   border-radius: var(--button-lg-border-radius);
-  color: var(--accent-color-stroke);
+  color: var(--accent-color-primary);
 }
 .btnPrimaryInvertSecondaryColor {
   border: 1px solid var(--accent-color-secondary);

--- a/packages/ui-buttons/src/ButtonSubmitInvert/index.module.scss
+++ b/packages/ui-buttons/src/ButtonSubmitInvert/index.module.scss
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 .btnSubmitInvert {
-  border: 1px solid var(--accent-color-stroke);
+  border: 1px solid var(--accent-color-primary);
   border-radius: var(--button-sm-border-radius);
-  color: var(--accent-color-stroke);
+  color: var(--accent-color-primary);
 }
 
 .btnSubmitInvertSm {

--- a/packages/ui-core/src/base/Entry/index.tsx
+++ b/packages/ui-core/src/base/Entry/index.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ComponentBase } from '@w3ux/types'
+import type { ForwardedRef } from 'react'
+import { forwardRef } from 'react'
 import classes from './index.module.scss'
 
 export type EntryProps = ComponentBase & {
@@ -13,11 +15,17 @@ export type EntryProps = ComponentBase & {
  * @name Entry
  * @summary The outer-most wrapper that hosts core tag styling.
  */
-export const Entry = ({ children, style, mode, theme }: EntryProps) => (
-  <div
-    className={`${classes.entry} theme-${mode} theme-${theme}`}
-    style={style}
-  >
-    {children}
-  </div>
+export const Entry = forwardRef(
+  (
+    { children, style, mode, theme }: EntryProps,
+    ref: ForwardedRef<HTMLDivElement>
+  ) => (
+    <div
+      ref={ref}
+      className={`${classes.entry} theme-${mode} theme-${theme}`}
+      style={style}
+    >
+      {children}
+    </div>
+  )
 )


### PR DESCRIPTION
Enhances and simplifies the codebase, iterating theming and allowing more intelligent theme solutions.

- [x] Adds a `ThemeValuesContext` to be able to fetch css variables via a `getThemeVariable` function.
- [x] Uses an observer to react to Entry `classList`.
- [x] Removes redundant network color configs.
- [x] Improves accent css configuration.