### PR TITLE
feat(refactor):  Staking API arg `chain` -> `network`

### DIFF
--- a/packages/app/src/StakingApi/FastUnstakeApi.tsx
+++ b/packages/app/src/StakingApi/FastUnstakeApi.tsx
@@ -9,7 +9,7 @@ import type { Props } from './types'
 export const FastUnstakeApi = ({ activeAccount, network }: Props) => {
   const { setFastUnstakeStatus } = useFastUnstake()
   const { data, loading, error } = useCanFastUnstake({
-    chain: network,
+    network,
     who: activeAccount,
   })
 

--- a/packages/app/src/StakingApi/UnclaimedRewardsApi.tsx
+++ b/packages/app/src/StakingApi/UnclaimedRewardsApi.tsx
@@ -11,7 +11,7 @@ export const UnclaimedRewardsApi = ({ activeAccount, network }: Props) => {
   const { activeEra } = useApi()
   const { setUnclaimedRewards } = usePayouts()
   const { data, loading, error } = useUnclaimedRewards({
-    chain: network,
+    network,
     who: activeAccount,
     fromEra: Math.max(activeEra.index.minus(1).toNumber(), 0),
   })

--- a/packages/app/src/overlay/canvas/Pool/Overview/Performance/ActiveGraph.tsx
+++ b/packages/app/src/overlay/canvas/Pool/Overview/Performance/ActiveGraph.tsx
@@ -23,7 +23,7 @@ export const ActiveGraph = ({
   units,
 }: Props) => {
   const { data, loading, error } = useRewards({
-    chain: network,
+    network,
     who: stash,
     fromEra,
   })

--- a/packages/app/src/overlay/canvas/ValidatorMetrics/EraPoints/ActiveGraph.tsx
+++ b/packages/app/src/overlay/canvas/ValidatorMetrics/EraPoints/ActiveGraph.tsx
@@ -20,7 +20,7 @@ export const ActiveGraph = ({
   height,
 }: Props) => {
   const { data, loading, error } = useValidatorEraPoints({
-    chain: network,
+    network,
     validator,
     fromEra,
   })

--- a/packages/app/src/overlay/canvas/ValidatorMetrics/Rewards/ActiveGraph.tsx
+++ b/packages/app/src/overlay/canvas/ValidatorMetrics/Rewards/ActiveGraph.tsx
@@ -25,7 +25,7 @@ export const ActiveGraph = ({
     networkData: { units },
   } = useNetwork()
   const { data, loading, error } = useValidatorRewards({
-    chain: network,
+    network,
     validator,
     fromEra,
   })

--- a/packages/app/src/pages/Overview/Payouts/ActiveGraph.tsx
+++ b/packages/app/src/pages/Overview/Payouts/ActiveGraph.tsx
@@ -32,7 +32,7 @@ export const ActiveGraph = ({
   const { activeAccount } = useActiveAccounts()
 
   const { data: nominatorRewardData, loading: rewardsLoading } = useRewards({
-    chain: network,
+    network,
     who: activeAccount || '',
     fromEra: Math.max(activeEra.index.minus(1).toNumber(), 0),
   })
@@ -44,7 +44,7 @@ export const ActiveGraph = ({
 
   const { data: poolRewardsData, loading: poolRewardsLoading } = usePoolRewards(
     {
-      chain: network,
+      network,
       who: activeAccount || '',
       from: getUnixTime(fromDate),
     }

--- a/packages/app/src/pages/Payouts/ActiveGraph.tsx
+++ b/packages/app/src/pages/Payouts/ActiveGraph.tsx
@@ -26,7 +26,7 @@ export const ActiveGraph = ({ nominating, inPool, setPayoutLists }: Props) => {
   const { activeAccount } = useActiveAccounts()
 
   const { data: nominatorRewardsData, loading: rewardsLoading } = useRewards({
-    chain: network,
+    network,
     who: activeAccount || '',
     fromEra: Math.max(activeEra.index.minus(1).toNumber(), 0),
   })
@@ -37,7 +37,7 @@ export const ActiveGraph = ({ nominating, inPool, setPayoutLists }: Props) => {
 
   const { data: poolRewardsData, loading: poolRewardsLoading } = usePoolRewards(
     {
-      chain: network,
+      network,
       who: activeAccount || '',
       from: getUnixTime(fromDate),
     }

--- a/packages/plugin-staking-api/src/queries/activeValidatorRanks.tsx
+++ b/packages/plugin-staking-api/src/queries/activeValidatorRanks.tsx
@@ -6,8 +6,8 @@ import { client } from '../Client'
 import type { ActiveValidatorRank, ActiveValidatorRanksResult } from '../types'
 
 const QUERY = gql`
-  query ActiveValidatorRanks($chain: String!) {
-    activeValidatorRanks(chain: $chain) {
+  query ActiveValidatorRanks($network: String!) {
+    activeValidatorRanks(network: $network) {
       validator
       rank
     }
@@ -15,23 +15,23 @@ const QUERY = gql`
 `
 
 export const useActiveValidatorRanks = ({
-  chain,
+  network,
 }: {
-  chain: string
+  network: string
 }): ActiveValidatorRanksResult => {
   const { loading, error, data, refetch } = useQuery(QUERY, {
-    variables: { chain },
+    variables: { network },
   })
   return { loading, error, data, refetch }
 }
 
 export const fetchActiveValidatorRanks = async (
-  chain: string
+  network: string
 ): Promise<{ activeValidatorRanks: ActiveValidatorRank[] }> => {
   try {
     const result = await client.query({
       query: QUERY,
-      variables: { chain },
+      variables: { network },
     })
     return result.data
   } catch (error) {

--- a/packages/plugin-staking-api/src/queries/canFastUnstake.tsx
+++ b/packages/plugin-staking-api/src/queries/canFastUnstake.tsx
@@ -5,22 +5,22 @@ import { gql, useQuery } from '@apollo/client'
 import type { CanFastUnstakeResult } from '../types'
 
 const QUERY = gql`
-  query PoolRewards($chain: String!, $who: String!) {
-    canFastUnstake(chain: $chain, who: $who) {
+  query PoolRewards($network: String!, $who: String!) {
+    canFastUnstake(network: $network, who: $who) {
       status
     }
   }
 `
 
 export const useCanFastUnstake = ({
-  chain,
+  network,
   who,
 }: {
-  chain: string
+  network: string
   who: string
 }): CanFastUnstakeResult => {
   const { loading, error, data, refetch } = useQuery(QUERY, {
-    variables: { chain, who },
+    variables: { network, who },
   })
   return { loading, error, data, refetch }
 }

--- a/packages/plugin-staking-api/src/queries/poolCandidates.tsx
+++ b/packages/plugin-staking-api/src/queries/poolCandidates.tsx
@@ -6,29 +6,29 @@ import { client } from '../Client'
 import type { PoolCandidatesResult } from '../types'
 
 const QUERY = gql`
-  query PoolCandidates($chain: String!) {
-    poolCandidates(chain: $chain)
+  query PoolCandidates($network: String!) {
+    poolCandidates(network: $network)
   }
 `
 
 export const usePoolCandidates = ({
-  chain,
+  network,
 }: {
-  chain: string
+  network: string
 }): PoolCandidatesResult => {
   const { loading, error, data, refetch } = useQuery(QUERY, {
-    variables: { chain },
+    variables: { network },
   })
   return { loading, error, data, refetch }
 }
 
 export const fetchPoolCandidates = async (
-  chain: string
+  network: string
 ): Promise<{ poolCandidates: number[] }> => {
   try {
     const result = await client.query({
       query: QUERY,
-      variables: { chain },
+      variables: { network },
     })
 
     return result.data

--- a/packages/plugin-staking-api/src/queries/poolEraPoints.tsx
+++ b/packages/plugin-staking-api/src/queries/poolEraPoints.tsx
@@ -6,13 +6,13 @@ import type { PoolEraPointsResult } from '../types'
 
 const QUERY = gql`
   query PoolEraPoints(
-    $chain: String!
+    $network: String!
     $poolId: Int!
     $fromEra: Int!
     $depth: Int
   ) {
     poolEraPoints(
-      chain: $chain
+      network: $network
       poolId: $poolId
       fromEra: $fromEra
       depth: $depth
@@ -25,18 +25,18 @@ const QUERY = gql`
 `
 
 export const usePoolEraPoints = ({
-  chain,
+  network,
   poolId,
   fromEra,
   depth,
 }: {
-  chain: string
+  network: string
   poolId: number
   fromEra: number
   depth?: number
 }): PoolEraPointsResult => {
   const { loading, error, data, refetch } = useQuery(QUERY, {
-    variables: { chain, poolId, fromEra, depth },
+    variables: { network, poolId, fromEra, depth },
   })
   return { loading, error, data, refetch }
 }

--- a/packages/plugin-staking-api/src/queries/poolRewards.tsx
+++ b/packages/plugin-staking-api/src/queries/poolRewards.tsx
@@ -5,8 +5,8 @@ import { gql, useQuery } from '@apollo/client'
 import type { PoolRewardResults } from '../types'
 
 const QUERY = gql`
-  query PoolRewards($chain: String!, $who: String!, $from: Int!) {
-    poolRewards(chain: $chain, who: $who, from: $from) {
+  query PoolRewards($network: String!, $who: String!, $from: Int!) {
+    poolRewards(network: $network, who: $who, from: $from) {
       poolId
       reward
       timestamp
@@ -16,16 +16,16 @@ const QUERY = gql`
 `
 
 export const usePoolRewards = ({
-  chain,
+  network,
   who,
   from,
 }: {
-  chain: string
+  network: string
   who: string
   from: number
 }): PoolRewardResults => {
   const { loading, error, data, refetch } = useQuery(QUERY, {
-    variables: { chain, who, from },
+    variables: { network, who, from },
   })
   return { loading, error, data, refetch }
 }

--- a/packages/plugin-staking-api/src/queries/rewards.tsx
+++ b/packages/plugin-staking-api/src/queries/rewards.tsx
@@ -5,8 +5,8 @@ import { gql, useQuery } from '@apollo/client'
 import type { AllRewardsResult } from '../types'
 
 const QUERY = gql`
-  query AllRewards($chain: String!, $who: String!, $fromEra: Int!) {
-    allRewards(chain: $chain, who: $who, fromEra: $fromEra) {
+  query AllRewards($network: String!, $who: String!, $fromEra: Int!) {
+    allRewards(network: $network, who: $who, fromEra: $fromEra) {
       claimed
       era
       reward
@@ -18,16 +18,16 @@ const QUERY = gql`
 `
 
 export const useRewards = ({
-  chain,
+  network,
   who,
   fromEra,
 }: {
-  chain: string
+  network: string
   who: string
   fromEra: number
 }): AllRewardsResult => {
   const { loading, error, data, refetch } = useQuery(QUERY, {
-    variables: { chain, who, fromEra },
+    variables: { network, who, fromEra },
   })
   return { loading, error, data, refetch }
 }

--- a/packages/plugin-staking-api/src/queries/unclaimedRewards.tsx
+++ b/packages/plugin-staking-api/src/queries/unclaimedRewards.tsx
@@ -5,8 +5,8 @@ import { gql, useQuery } from '@apollo/client'
 import type { UnclaimedRewardsResult } from '../types'
 
 const QUERY = gql`
-  query UnclaimedRewards($chain: String!, $who: String!, $fromEra: Int!) {
-    unclaimedRewards(chain: $chain, who: $who, fromEra: $fromEra) {
+  query UnclaimedRewards($network: String!, $who: String!, $fromEra: Int!) {
+    unclaimedRewards(network: $network, who: $who, fromEra: $fromEra) {
       total
       entries {
         era
@@ -22,16 +22,16 @@ const QUERY = gql`
 `
 
 export const useUnclaimedRewards = ({
-  chain,
+  network,
   who,
   fromEra,
 }: {
-  chain: string
+  network: string
   who: string
   fromEra: number
 }): UnclaimedRewardsResult => {
   const { loading, error, data, refetch } = useQuery(QUERY, {
-    variables: { chain, who, fromEra },
+    variables: { network, who, fromEra },
   })
   return { loading, error, data, refetch }
 }

--- a/packages/plugin-staking-api/src/queries/validatorEraPoints.tsx
+++ b/packages/plugin-staking-api/src/queries/validatorEraPoints.tsx
@@ -6,13 +6,13 @@ import type { ValidatorEraPointsResult } from '../types'
 
 const QUERY = gql`
   query ValidatorEraPoints(
-    $chain: String!
+    $network: String!
     $validator: String!
     $fromEra: Int!
     $depth: Int
   ) {
     validatorEraPoints(
-      chain: $chain
+      network: $network
       validator: $validator
       fromEra: $fromEra
       depth: $depth
@@ -25,18 +25,18 @@ const QUERY = gql`
 `
 
 export const useValidatorEraPoints = ({
-  chain,
+  network,
   validator,
   fromEra,
   depth,
 }: {
-  chain: string
+  network: string
   validator: string
   fromEra: number
   depth?: number
 }): ValidatorEraPointsResult => {
   const { loading, error, data, refetch } = useQuery(QUERY, {
-    variables: { chain, validator, fromEra, depth },
+    variables: { network, validator, fromEra, depth },
   })
   return { loading, error, data, refetch }
 }

--- a/packages/plugin-staking-api/src/queries/validatorEraPointsBatch.tsx
+++ b/packages/plugin-staking-api/src/queries/validatorEraPointsBatch.tsx
@@ -10,13 +10,13 @@ import type {
 
 const QUERY = gql`
   query ValidatorEraPointsBatch(
-    $chain: String!
+    $network: String!
     $validators: [String!]!
     $fromEra: Int!
     $depth: Int
   ) {
     validatorEraPointsBatch(
-      chain: $chain
+      network: $network
       validators: $validators
       fromEra: $fromEra
       depth: $depth
@@ -32,24 +32,24 @@ const QUERY = gql`
 `
 
 export const useValidatorEraPointsBatch = ({
-  chain,
+  network,
   validators,
   fromEra,
   depth,
 }: {
-  chain: string
+  network: string
   validators: string[]
   fromEra: number
   depth?: number
 }): ValidatorEraPointsBatchResult => {
   const { loading, error, data, refetch } = useQuery(QUERY, {
-    variables: { chain, validators, fromEra, depth },
+    variables: { network, validators, fromEra, depth },
   })
   return { loading, error, data, refetch }
 }
 
 export const fetchValidatorEraPointsBatch = async (
-  chain: string,
+  network: string,
   validators: string[],
   fromEra: number,
   depth?: number
@@ -57,7 +57,7 @@ export const fetchValidatorEraPointsBatch = async (
   try {
     const result = await client.query({
       query: QUERY,
-      variables: { chain, validators, fromEra, depth },
+      variables: { network, validators, fromEra, depth },
     })
     return result.data
   } catch (error) {

--- a/packages/plugin-staking-api/src/queries/validatorRewards.tsx
+++ b/packages/plugin-staking-api/src/queries/validatorRewards.tsx
@@ -6,13 +6,13 @@ import type { ValidatorRewardsResult } from '../types'
 
 const QUERY = gql`
   query ValidatorRewards(
-    $chain: String!
+    $network: String!
     $validator: String!
     $fromEra: Int!
     $depth: Int
   ) {
     validatorRewards(
-      chain: $chain
+      network: $network
       validator: $validator
       fromEra: $fromEra
       depth: $depth
@@ -25,18 +25,18 @@ const QUERY = gql`
 `
 
 export const useValidatorRewards = ({
-  chain,
+  network,
   validator,
   fromEra,
   depth,
 }: {
-  chain: string
+  network: string
   validator: string
   fromEra: number
   depth?: number
 }): ValidatorRewardsResult => {
   const { loading, error, data, refetch } = useQuery(QUERY, {
-    variables: { chain, validator, fromEra, depth },
+    variables: { network, validator, fromEra, depth },
   })
   return { loading, error, data, refetch }
 }


### PR DESCRIPTION
Staking API queries are now using a `network` argument instead of a `chain` argument.