### PR TITLE
feat(ux): Amend side menu toggle to top of menu

### DIFF
--- a/packages/app/src/library/SideMenu/Wrapper.ts
+++ b/packages/app/src/library/SideMenu/Wrapper.ts
@@ -55,7 +55,7 @@ export const Wrapper = styled.div<MinimisedProps>`
         position: relative;
         transition: color var(--transition-duration);
         margin-top: ${(props) => (props.$minimised ? '1rem' : 0)};
-        margin-right: ${(props) => (props.$minimised ? 0 : '0.9rem')};
+        margin-right: ${(props) => (props.$minimised ? 0 : '1.25rem')};
         opacity: 0.75;
         padding: 0.1rem;
 
@@ -74,7 +74,7 @@ export const Wrapper = styled.div<MinimisedProps>`
   }
 `
 
-export const LogoWrapper = styled.div<MinimisedProps>`
+export const LogoWrapper = styled.button<MinimisedProps>`
   display: flex;
   flex-flow: row wrap;
   justify-content: ${(props) => (props.$minimised ? 'center' : 'flex-start')};
@@ -82,10 +82,30 @@ export const LogoWrapper = styled.div<MinimisedProps>`
   width: 100%;
   height: 2.8rem;
   padding: ${(props) => (props.$minimised ? '0' : '0.4rem 0 0.4rem 0.5rem')};
+  margin-top: ${(props) => (props.$minimised ? '0' : '0.6rem')};
   margin-bottom: ${(props) => (props.$minimised ? '0.75rem' : '0.5rem')};
   position: relative;
   text-transform: uppercase;
 
+  > .toggle {
+    position: absolute;
+    top: ${(props) => (props.$minimised ? '1rem' : '-0.1rem')};
+    right: ${(props) => (props.$minimised ? '-0.75rem' : '0')};
+    height: 100%;
+    display: flex;
+    align-items: center;
+
+    > .label {
+      background: var(--background-primary);
+      color: var(--text-color-secondary);
+      width: 1.75rem;
+      height: 1.75rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+    }
+  }
   > span {
     margin-top: 0.25rem;
     margin-left: 0.75rem;
@@ -95,7 +115,13 @@ export const LogoWrapper = styled.div<MinimisedProps>`
 
     .logo {
       width: auto;
-      height: 1.4rem;
+      height: 1.5rem;
+    }
+  }
+
+  &:hover {
+    > .toggle > .label {
+      color: var(--accent-color-primary);
     }
   }
 `

--- a/packages/app/src/library/SideMenu/Wrapper.ts
+++ b/packages/app/src/library/SideMenu/Wrapper.ts
@@ -89,8 +89,8 @@ export const LogoWrapper = styled.button<MinimisedProps>`
 
   > .toggle {
     position: absolute;
-    top: ${(props) => (props.$minimised ? '1rem' : '-0.1rem')};
-    right: ${(props) => (props.$minimised ? '-0.75rem' : '0')};
+    top: ${(props) => (props.$minimised ? '0.9rem' : '-0.1rem')};
+    right: ${(props) => (props.$minimised ? '-0.65rem' : '0')};
     height: 100%;
     display: flex;
     align-items: center;
@@ -115,7 +115,7 @@ export const LogoWrapper = styled.button<MinimisedProps>`
 
     .logo {
       width: auto;
-      height: 1.5rem;
+      height: ${(props) => (props.$minimised ? '2.15rem' : '1.5rem')};
     }
   }
 

--- a/packages/app/src/library/SideMenu/index.tsx
+++ b/packages/app/src/library/SideMenu/index.tsx
@@ -83,14 +83,14 @@ export const SideMenu = () => {
             onClick={() => setUserSideMenuMinimised(!userSideMenuMinimised)}
           >
             {sideMenuMinimised ? (
-              <CloudSVG style={{ maxHeight: '100%', width: '1.8rem' }} />
+              <CloudSVG style={{ maxHeight: '100%', width: '2rem' }} />
             ) : (
               <>
                 <CloudSVG
                   style={{
                     maxHeight: '100%',
                     height: '100%',
-                    width: '1.65rem',
+                    width: '1.55rem',
                   }}
                 />
                 <span>

--- a/packages/app/src/library/SideMenu/index.tsx
+++ b/packages/app/src/library/SideMenu/index.tsx
@@ -1,7 +1,10 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { faCompressAlt, faExpandAlt } from '@fortawesome/free-solid-svg-icons'
+import {
+  faChevronLeft,
+  faChevronRight,
+} from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useOnResize, useOutsideAlerter } from '@w3ux/hooks'
 import { capitalizeFirstLetter } from '@w3ux/utils'
@@ -74,7 +77,11 @@ export const SideMenu = () => {
     >
       <Wrapper ref={ref} $minimised={sideMenuMinimised}>
         <section>
-          <LogoWrapper $minimised={sideMenuMinimised}>
+          <LogoWrapper
+            $minimised={sideMenuMinimised}
+            type="button"
+            onClick={() => setUserSideMenuMinimised(!userSideMenuMinimised)}
+          >
             {sideMenuMinimised ? (
               <CloudSVG style={{ maxHeight: '100%', width: '1.8rem' }} />
             ) : (
@@ -90,6 +97,16 @@ export const SideMenu = () => {
                   <LogoSVG className="logo" />
                 </span>
               </>
+            )}
+            {!sideMenuOpen && (
+              <span className="toggle">
+                <span className="label">
+                  <FontAwesomeIcon
+                    icon={sideMenuMinimised ? faChevronRight : faChevronLeft}
+                    transform="shrink-5"
+                  />
+                </span>
+              </span>
             )}
           </LogoWrapper>
           <Heading title={t('network')} minimised={sideMenuMinimised} />
@@ -148,15 +165,6 @@ export const SideMenu = () => {
         </section>
 
         <section>
-          <button
-            type="button"
-            onClick={() => setUserSideMenuMinimised(!userSideMenuMinimised)}
-            aria-label="Menu"
-          >
-            <FontAwesomeIcon
-              icon={userSideMenuMinimised ? faExpandAlt : faCompressAlt}
-            />
-          </button>
           <button
             type="button"
             onClick={() =>


### PR DESCRIPTION
In preparation of re-purposing the bottom left section of the side menu, the menu minimise toggle has been moved to the top of the menu to accompany the cloud icon, forming one large button.