### PR TITLE
feat(ux): Shrink maximised side menu

### DIFF
--- a/packages/app/src/common-types.ts
+++ b/packages/app/src/common-types.ts
@@ -135,11 +135,7 @@ export interface PageItem {
   hash: string
   Entry: FC<PageProps>
   lottie: AnyJson
-  action?: {
-    type: string
-    status: string
-    text?: string | undefined
-  }
+  bullet?: BulletType
 }
 
 export type PagesConfigItems = PageItem[]
@@ -157,3 +153,5 @@ export type AnyApi = any
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyMetaBatch = any
+
+export type BulletType = 'success' | 'accent' | 'warning'

--- a/packages/app/src/common-types.ts
+++ b/packages/app/src/common-types.ts
@@ -154,4 +154,4 @@ export type AnyApi = any
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyMetaBatch = any
 
-export type BulletType = 'success' | 'accent' | 'warning'
+export type BulletType = 'success' | 'accent' | 'warning' | 'danger'

--- a/packages/app/src/library/SideMenu/Main.tsx
+++ b/packages/app/src/library/SideMenu/Main.tsx
@@ -29,15 +29,15 @@ export const Main = () => {
   const { pathname } = useLocation()
   const { inPool } = useActivePool()
   const { networkData } = useNetwork()
+  const {
+    getPoolSetupPercent,
+    getNominatorSetupPercent,
+  }: SetupContextInterface = useSetup()
   const { getNominations } = useBalances()
   const { getBondedAccount } = useBonded()
   const { accounts } = useImportedAccounts()
   const { formatWithPrefs } = useValidators()
   const { activeAccount } = useActiveAccounts()
-  const {
-    getPoolSetupPercent,
-    getNominatorSetupPercent,
-  }: SetupContextInterface = useSetup()
   const { sideMenuMinimised }: UIContextInterface = useUi()
   const { inSetup: inNominatorSetup, addressDifferentToStash } = useStaking()
 
@@ -54,62 +54,41 @@ export const Main = () => {
     pages: Object.assign(PagesConfig),
   })
 
+  // Configure side menu bullets for active account
   useEffect(() => {
     if (!accounts.length) {
       return
     }
-
-    // inject actions into menu items
-    const pages = Object.assign(pageConfig.pages)
+    // Inject actions into menu items
+    const pages: PageItem[] = Object.assign(pageConfig.pages)
 
     let i = 0
     for (const { uri } of pages) {
-      // set undefined action as default
-      pages[i].action = undefined
       if (uri === `${import.meta.env.BASE_URL}`) {
         const warning = !syncing && controllerDifferentToStash
         if (warning) {
-          pages[i].action = {
-            type: 'bullet',
-            status: 'warning',
-          }
+          pages[i].bullet = 'warning'
         }
       }
-
       if (uri === `${import.meta.env.BASE_URL}nominate`) {
-        // configure Stake action
         const staking = !inNominatorSetup()
-        const warning =
+        if (staking) {
+          pages[i].bullet = 'accent'
+        }
+        if (
           (!syncing && controllerDifferentToStash) ||
           (!inNominatorSetup() && fullCommissionNominees.length > 0)
-
-        if (staking) {
-          pages[i].action = {
-            type: 'bullet',
-            status: 'accent',
-          }
-        }
-        if (warning) {
-          pages[i].action = {
-            type: 'bullet',
-            status: 'warning',
-          }
+        ) {
+          pages[i].bullet = 'warning'
         }
       }
-
       if (uri === `${import.meta.env.BASE_URL}pools`) {
-        // configure Pools action
-
         if (inPool()) {
-          pages[i].action = {
-            type: 'bullet',
-            status: 'accent',
-          }
+          pages[i].bullet = 'accent'
         }
       }
       i++
     }
-
     setPageConfig({
       categories: pageConfig.categories,
       pages,
@@ -135,14 +114,11 @@ export const Main = () => {
       {pageConfig.categories.map(
         ({ id: categoryId, key: categoryKey }: PageCategory) => (
           <div className="inner" key={`sidemenu_category_${categoryId}`}>
-            {/* display heading if not `default` (used for top links) */}
             {categoryKey !== 'default' && (
               <Heading title={t(categoryKey)} minimised={sideMenuMinimised} />
             )}
-
-            {/* display category links */}
             {pagesToDisplay.map(
-              ({ category, hash, key, lottie, action }: PageItem) => (
+              ({ category, hash, key, lottie, bullet }: PageItem) => (
                 <Fragment key={`sidemenu_page_${categoryId}_${key}`}>
                   {category === categoryId && (
                     <Primary
@@ -150,7 +126,7 @@ export const Main = () => {
                       to={hash}
                       active={hash === pathname}
                       lottie={lottie}
-                      action={action}
+                      bullet={bullet}
                       minimised={sideMenuMinimised}
                     />
                   )}

--- a/packages/app/src/library/SideMenu/Main.tsx
+++ b/packages/app/src/library/SideMenu/Main.tsx
@@ -85,9 +85,8 @@ export const Main = () => {
 
         if (staking) {
           pages[i].action = {
-            type: 'text',
-            status: 'success',
-            text: t('active'),
+            type: 'bullet',
+            status: 'accent',
           }
         }
         if (warning) {
@@ -103,9 +102,8 @@ export const Main = () => {
 
         if (inPool()) {
           pages[i].action = {
-            type: 'text',
-            status: 'success',
-            text: t('active'),
+            type: 'bullet',
+            status: 'accent',
           }
         }
       }

--- a/packages/app/src/library/SideMenu/Primary/Wrappers.ts
+++ b/packages/app/src/library/SideMenu/Primary/Wrappers.ts
@@ -23,7 +23,8 @@ export const Wrapper = styled(motion.div)`
     margin: 0.7rem 0.2rem 0.5rem 0;
     padding: 0.65rem 0rem;
 
-    &.success {
+    &.success,
+    &.accent {
       border: 1px solid var(--accent-color-primary);
     }
     &.warning {
@@ -34,9 +35,9 @@ export const Wrapper = styled(motion.div)`
   .dotlottie {
     color: var(--text-color-primary);
     margin-left: 0.25rem;
-    margin-right: 0.65rem;
-    width: 1.35rem;
-    height: 1.35rem;
+    margin-right: 0.5rem;
+    width: 1.2rem;
+    height: 1.2rem;
     .fa-icon {
       margin: 0 0.15rem;
     }
@@ -83,6 +84,11 @@ export const Wrapper = styled(motion.div)`
     &.warning {
       svg {
         color: var(--accent-color-secondary);
+      }
+    }
+    &.accent {
+      svg {
+        color: var(--accent-color-primary);
       }
     }
     &.minimised {

--- a/packages/app/src/library/SideMenu/Primary/Wrappers.ts
+++ b/packages/app/src/library/SideMenu/Primary/Wrappers.ts
@@ -53,53 +53,6 @@ export const Wrapper = styled(motion.div)`
     padding: 0;
     line-height: 1.35rem;
   }
-  .action {
-    color: var(--status-success-color);
-    display: flex;
-    flex: 1;
-    font-size: 0.88rem;
-    flex-flow: row wrap;
-    justify-content: flex-end;
-    margin-right: 0.4rem;
-    opacity: 0.7;
-
-    > span {
-      &.success {
-        color: var(--accent-color-primary);
-        border: 1px solid var(--accent-color-primary);
-      }
-      &.warning {
-        color: var(--accent-color-secondary);
-        border: 1px solid var(--accent-color-secondary);
-      }
-      border-radius: 0.5rem;
-      padding: 0.15rem 0.5rem;
-    }
-
-    &.success {
-      svg {
-        color: var(--status-success-color);
-      }
-    }
-    &.warning {
-      svg {
-        color: var(--accent-color-secondary);
-      }
-    }
-    &.accent {
-      svg {
-        color: var(--accent-color-primary);
-      }
-    }
-    &.minimised {
-      > svg {
-        flex: 0;
-        position: absolute;
-        right: -3px;
-        top: -4px;
-      }
-    }
-  }
 
   &.active {
     background: var(--highlight-primary);

--- a/packages/app/src/library/SideMenu/Primary/index.tsx
+++ b/packages/app/src/library/SideMenu/Primary/index.tsx
@@ -7,6 +7,7 @@ import { useUi } from 'contexts/UI'
 import { useDotLottieButton } from 'hooks/useDotLottieButton'
 import { Link } from 'react-router-dom'
 import type { PrimaryProps } from '../types'
+import { BulletWrapper } from '../Wrapper'
 import { Wrapper } from './Wrappers'
 
 export const Primary = ({
@@ -48,9 +49,9 @@ export const Primary = ({
           <>
             <h4 className="name">{name}</h4>
             {bullet && (
-              <div className={`action ${bullet}`}>
+              <BulletWrapper className={bullet}>
                 <FontAwesomeIcon icon={faCircle} transform="shrink-6" />
-              </div>
+              </BulletWrapper>
             )}
           </>
         )}

--- a/packages/app/src/library/SideMenu/Primary/index.tsx
+++ b/packages/app/src/library/SideMenu/Primary/index.tsx
@@ -13,28 +13,13 @@ export const Primary = ({
   name,
   active,
   to,
-  action,
+  bullet,
   minimised,
   lottie,
 }: PrimaryProps) => {
   const { setSideMenu } = useUi()
 
   const { icon, play } = useDotLottieButton(lottie)
-
-  let Action = null
-  const actionStatus = action?.status ?? null
-
-  switch (action?.type) {
-    case 'bullet':
-      Action = (
-        <div className={`action ${actionStatus}`}>
-          <FontAwesomeIcon icon={faCircle} transform="shrink-6" />
-        </div>
-      )
-      break
-    default:
-      Action = null
-  }
 
   return (
     <Link
@@ -49,7 +34,7 @@ export const Primary = ({
       <Wrapper
         className={`${active ? `active` : `inactive`}${
           minimised ? ` minimised` : ``
-        }${action ? ` ${actionStatus}` : ``}`}
+        }${bullet ? ` ${bullet}` : ``}`}
         whileHover={{ scale: 1.02 }}
         whileTap={{ scale: 0.98 }}
         transition={{
@@ -61,7 +46,12 @@ export const Primary = ({
         </div>
         {!minimised && (
           <>
-            <h4 className="name">{name}</h4> {Action}
+            <h4 className="name">{name}</h4>
+            {bullet && (
+              <div className={`action ${bullet}`}>
+                <FontAwesomeIcon icon={faCircle} transform="shrink-6" />
+              </div>
+            )}
           </>
         )}
       </Wrapper>

--- a/packages/app/src/library/SideMenu/Primary/index.tsx
+++ b/packages/app/src/library/SideMenu/Primary/index.tsx
@@ -25,19 +25,10 @@ export const Primary = ({
   const actionStatus = action?.status ?? null
 
   switch (action?.type) {
-    case 'text':
-      Action = (
-        <div className="action text">
-          <span className={actionStatus || undefined}>
-            {action?.text ?? ''}
-          </span>
-        </div>
-      )
-      break
     case 'bullet':
       Action = (
         <div className={`action ${actionStatus}`}>
-          <FontAwesomeIcon icon={faCircle} transform="shrink-4" />
+          <FontAwesomeIcon icon={faCircle} transform="shrink-6" />
         </div>
       )
       break

--- a/packages/app/src/library/SideMenu/Secondary/Wrappers.ts
+++ b/packages/app/src/library/SideMenu/Secondary/Wrappers.ts
@@ -13,7 +13,7 @@ export const Wrapper = styled(motion.button)<MinimisedProps>`
   flex-flow: row wrap;
   align-items: center;
   position: relative;
-  padding: 0.75rem 0rem 0.75rem 0.5rem;
+  padding: 0rem 0.5rem;
   margin: 0.8rem 0.2rem 1rem 0;
   width: 100%;
 
@@ -25,13 +25,6 @@ export const Wrapper = styled(motion.button)<MinimisedProps>`
   .light {
     color: var(--text-color-primary);
     margin-left: 0.2rem;
-  }
-  .action {
-    color: var(--text-color-primary);
-    flex: 1;
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: flex-end;
   }
 
   &.active {
@@ -59,7 +52,7 @@ export const MinimisedWrapper = styled(motion.button)`
   justify-content: center;
   align-items: center;
   position: relative;
-  padding: 0rem 0rem;
+  padding: 0;
   margin: 0.6rem 0 1.15rem 0;
   min-height: 3.2rem;
   width: 100%;
@@ -73,14 +66,7 @@ export const MinimisedWrapper = styled(motion.button)`
   .icon {
     margin: 0;
   }
-  .action {
-    &.minimised {
-      flex: 0;
-      position: absolute;
-      top: -2px;
-      right: -13px;
-    }
-  }
+
   &.success {
     border: 1px solid var(--status-success-color-transparent);
   }
@@ -93,6 +79,9 @@ export const MinimisedWrapper = styled(motion.button)`
 `
 
 export const IconWrapper = styled.div<{ $minimised: boolean }>`
+  height: 2rem;
+  display: flex;
+  align-items: center;
   margin-left: ${(props) => (props.$minimised ? 0 : '0.25rem')};
   margin-right: ${(props) => (props.$minimised ? 0 : '0.65rem')};
 

--- a/packages/app/src/library/SideMenu/Secondary/index.tsx
+++ b/packages/app/src/library/SideMenu/Secondary/index.tsx
@@ -1,11 +1,14 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import { faCircle } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import type { SecondaryProps } from '../types'
+import { BulletWrapper } from '../Wrapper'
 import { IconWrapper, MinimisedWrapper, Wrapper } from './Wrappers'
 
 export const Secondary = ({
-  action,
+  bullet,
   classes,
   name,
   icon,
@@ -39,7 +42,11 @@ export const Secondary = ({
       {!minimised && (
         <>
           <div className="name">{name}</div>
-          {action && <div className="action">{action}</div>}
+          {bullet && (
+            <BulletWrapper className={bullet}>
+              <FontAwesomeIcon icon={faCircle} transform="shrink-6" />
+            </BulletWrapper>
+          )}
         </>
       )}
     </StyledWrapper>

--- a/packages/app/src/library/SideMenu/Wrapper.ts
+++ b/packages/app/src/library/SideMenu/Wrapper.ts
@@ -138,23 +138,55 @@ export const Separator = styled.div`
   margin: 1rem 1rem 0.5rem 0;
 `
 
-export const ConnectionSymbol = styled.div`
-  width: 0.53rem;
-  height: 0.53rem;
-  background: ${(props) => props.color};
-  border-radius: 50%;
-  margin: 0 0.7rem;
+export const BulletWrapper = styled.div`
+  color: var(--status-success-color);
+  display: flex;
+  flex: 1;
+  font-size: 0.88rem;
+  flex-flow: row wrap;
+  justify-content: flex-end;
+  margin-right: 0.4rem;
+  opacity: 0.7;
+
+  > span {
+    &.success {
+      color: var(--accent-color-primary);
+      border: 1px solid var(--accent-color-primary);
+    }
+    &.warning {
+      color: var(--accent-color-secondary);
+      border: 1px solid var(--accent-color-secondary);
+    }
+    border-radius: 0.5rem;
+    padding: 0.15rem 0.5rem;
+  }
 
   &.success {
-    background: var(--status-success-color);
-    color: var(--status-success-color);
+    svg {
+      color: var(--status-success-color);
+    }
   }
   &.warning {
-    background: var(--status-warning-color);
-    color: var(--status-warning-color);
+    svg {
+      color: var(--accent-color-secondary);
+    }
+  }
+  &.accent {
+    svg {
+      color: var(--accent-color-primary);
+    }
   }
   &.danger {
-    background: var(--status-danger-color);
-    color: var(--status-danger-color);
+    svg {
+      color: var(--status-danger-color);
+    }
+  }
+  &.minimised {
+    > svg {
+      flex: 0;
+      position: absolute;
+      right: -3px;
+      top: -4px;
+    }
   }
 `

--- a/packages/app/src/library/SideMenu/Wrapper.ts
+++ b/packages/app/src/library/SideMenu/Wrapper.ts
@@ -104,8 +104,8 @@ export const LogoWrapper = styled.button<MinimisedProps>`
     > .label {
       background: var(--background-primary);
       color: var(--text-color-secondary);
-      width: 1.75rem;
-      height: 1.75rem;
+      width: 1.5rem;
+      height: 1.5rem;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/packages/app/src/library/SideMenu/Wrapper.ts
+++ b/packages/app/src/library/SideMenu/Wrapper.ts
@@ -3,6 +3,7 @@
 
 import {
   PageWidthMediumThreshold,
+  SideMenuHiddenWidth,
   SideMenuMaximisedWidth,
   SideMenuMinimisedWidth,
 } from 'consts'
@@ -22,6 +23,11 @@ export const Wrapper = styled.div<MinimisedProps>`
     props.$minimised
       ? `${SideMenuMinimisedWidth}px`
       : `${SideMenuMaximisedWidth}px`};
+
+  @media (max-width: ${PageWidthMediumThreshold}px) {
+    width: ${SideMenuHiddenWidth}px;
+  }
+
   padding: ${(props) =>
     props.$minimised ? `0.5rem 1rem 0.5rem 1rem` : `0rem 1rem 1rem 1rem`};
   margin: 0.75rem 0;
@@ -55,7 +61,7 @@ export const Wrapper = styled.div<MinimisedProps>`
         position: relative;
         transition: color var(--transition-duration);
         margin-top: ${(props) => (props.$minimised ? '1rem' : 0)};
-        margin-right: ${(props) => (props.$minimised ? 0 : '1.25rem')};
+        margin-right: ${(props) => (props.$minimised ? 0 : '1rem')};
         opacity: 0.75;
         padding: 0.1rem;
 
@@ -133,8 +139,8 @@ export const Separator = styled.div`
 `
 
 export const ConnectionSymbol = styled.div`
-  width: 0.6rem;
-  height: 0.6rem;
+  width: 0.53rem;
+  height: 0.53rem;
   background: ${(props) => props.color};
   border-radius: 50%;
   margin: 0 0.7rem;

--- a/packages/app/src/library/SideMenu/Wrapper.ts
+++ b/packages/app/src/library/SideMenu/Wrapper.ts
@@ -96,7 +96,7 @@ export const LogoWrapper = styled.button<MinimisedProps>`
   > .toggle {
     position: absolute;
     top: ${(props) => (props.$minimised ? '0.9rem' : '-0.1rem')};
-    right: ${(props) => (props.$minimised ? '-0.65rem' : '0')};
+    right: ${(props) => (props.$minimised ? '-0.25rem' : '0')};
     height: 100%;
     display: flex;
     align-items: center;

--- a/packages/app/src/library/SideMenu/index.tsx
+++ b/packages/app/src/library/SideMenu/index.tsx
@@ -18,7 +18,7 @@ import LanguageSVG from 'assets/svg/icons/language.svg?react'
 import LogoSVG from 'assets/svg/icons/logo.svg?react'
 import MoonOutlineSVG from 'assets/svg/icons/moon.svg?react'
 import SunnyOutlineSVG from 'assets/svg/icons/sun.svg?react'
-import { PageWidthMediumThreshold, SideMenuMaximisedWidth } from 'consts'
+import { PageWidthMediumThreshold } from 'consts'
 import { useApi } from 'contexts/Api'
 import { useHelp } from 'contexts/Help'
 import { useNetwork } from 'contexts/Network'
@@ -70,11 +70,7 @@ export const SideMenu = () => {
         : 'danger'
 
   return (
-    <Page.Side
-      open={sideMenuOpen}
-      minimised={sideMenuMinimised}
-      width={`${SideMenuMaximisedWidth}px`}
-    >
+    <Page.Side open={sideMenuOpen} minimised={sideMenuMinimised}>
       <Wrapper ref={ref} $minimised={sideMenuMinimised}>
         <section>
           <LogoWrapper

--- a/packages/app/src/library/SideMenu/index.tsx
+++ b/packages/app/src/library/SideMenu/index.tsx
@@ -32,7 +32,7 @@ import { useOverlay } from 'ui-overlay'
 import { Heading } from './Heading/Heading'
 import { Main } from './Main'
 import { Secondary } from './Secondary'
-import { ConnectionSymbol, LogoWrapper, Separator, Wrapper } from './Wrapper'
+import { LogoWrapper, Separator, Wrapper } from './Wrapper'
 
 export const SideMenu = () => {
   const { t } = useTranslation('base')
@@ -115,12 +115,7 @@ export const SideMenu = () => {
               size: networkData.brand.inline.size,
             }}
             minimised={sideMenuMinimised}
-            action={
-              <ConnectionSymbol
-                className={apiStatusClass}
-                style={{ opacity: 0.7 }}
-              />
-            }
+            bullet={apiStatusClass}
           />
           <Separator />
           <Main />
@@ -134,7 +129,7 @@ export const SideMenu = () => {
               minimised={sideMenuMinimised}
               icon={{
                 Svg: BookSVG,
-                size: sideMenuMinimised ? '0.95em' : '0.9em',
+                size: sideMenuMinimised ? '0.95em' : '0.8em',
               }}
             />
             <Secondary
@@ -143,7 +138,7 @@ export const SideMenu = () => {
               minimised={sideMenuMinimised}
               icon={{
                 Svg: DiscordSVG,
-                size: sideMenuMinimised ? '1.2em' : '1.2em',
+                size: sideMenuMinimised ? '1.2em' : '1em',
               }}
             />
             <Secondary
@@ -152,7 +147,7 @@ export const SideMenu = () => {
               minimised={sideMenuMinimised}
               icon={{
                 Svg: EnvelopeSVG,
-                size: sideMenuMinimised ? '1.05em' : '1em',
+                size: sideMenuMinimised ? '1.05em' : '0.9em',
               }}
             />
           </div>

--- a/packages/app/src/library/SideMenu/index.tsx
+++ b/packages/app/src/library/SideMenu/index.tsx
@@ -99,7 +99,7 @@ export const SideMenu = () => {
                 <span className="label">
                   <FontAwesomeIcon
                     icon={sideMenuMinimised ? faChevronRight : faChevronLeft}
-                    transform="shrink-5"
+                    transform="shrink-6"
                   />
                 </span>
               </span>

--- a/packages/app/src/library/SideMenu/types.ts
+++ b/packages/app/src/library/SideMenu/types.ts
@@ -3,7 +3,7 @@
 
 import type { AnyJson } from '@w3ux/types'
 import type { BulletType } from 'common-types'
-import type { FunctionComponent, ReactNode, SVGProps } from 'react'
+import type { FunctionComponent, SVGProps } from 'react'
 
 export interface MinimisedProps {
   $minimised?: boolean
@@ -30,7 +30,7 @@ export interface SecondaryProps {
   active?: boolean
   to?: string
   icon: IconProps
-  action?: ReactNode
+  bullet?: BulletType
   minimised: boolean
 }
 

--- a/packages/app/src/library/SideMenu/types.ts
+++ b/packages/app/src/library/SideMenu/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { AnyJson } from '@w3ux/types'
+import type { BulletType } from 'common-types'
 import type { FunctionComponent, ReactNode, SVGProps } from 'react'
 
 export interface MinimisedProps {
@@ -18,7 +19,7 @@ export interface PrimaryProps {
   active: boolean
   to: string
   lottie: AnyJson
-  action: undefined | { type: string; status: string; text?: string }
+  bullet?: BulletType
   minimised: boolean
 }
 

--- a/packages/consts/src/index.ts
+++ b/packages/consts/src/index.ts
@@ -13,7 +13,8 @@ export const MailSupportAddress = 'staking@polkadot.cloud'
  * Element Thresholds
  */
 export const MaxPageWidth = 1450
-export const SideMenuMaximisedWidth = 195
+export const SideMenuHiddenWidth = 195
+export const SideMenuMaximisedWidth = 145
 export const SideMenuMinimisedWidth = 75
 export const SectionFullWidthThreshold = 1000
 export const PageWidthMediumThreshold = 1150

--- a/packages/styles/theme/_variables.scss
+++ b/packages/styles/theme/_variables.scss
@@ -4,4 +4,6 @@ SPDX-License-Identifier: GPL-3.0-only */
 $page-width-medium-threshold: 1150px;
 $page-width-small-threshold: 826px;
 $row-section-thirds-threshold: 1400px;
+$side-menu-maximised-width: 145px;
 $side-menu-minimised-width: 75px;
+$side-menu-hidden-width: 195px;

--- a/packages/ui-core/src/base/Page/Side/index.module.scss
+++ b/packages/ui-core/src/base/Page/Side/index.module.scss
@@ -5,8 +5,8 @@
 
 .side {
   /* maximised by default, or minimised otherwise. */
-  min-width: var(--core-side-width);
-  max-width: var(--core-side-width);
+  min-width: $side-menu-maximised-width;
+  max-width: $side-menu-maximised-width;
   z-index: 7;
   position: sticky;
   top: 0;
@@ -18,6 +18,8 @@
   transition: all 0.5s cubic-bezier(0.1, 1, 0.2, 1);
 
   @media (max-width: $page-width-medium-threshold) {
+    min-width: $side-menu-hidden-width;
+    max-width: $side-menu-hidden-width;
     position: fixed;
     top: 0;
     left: 0;
@@ -31,6 +33,6 @@
 
 .sideHidden {
   @media (max-width: $page-width-medium-threshold) {
-    left: calc(var(--core-side-width) * -1);
+    left: calc($side-menu-hidden-width * -1);
   }
 }

--- a/packages/ui-core/src/base/Page/Side/index.tsx
+++ b/packages/ui-core/src/base/Page/Side/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import classNames from 'classnames'
-import type { CSSProperties } from 'react'
 import classes from './index.module.scss'
 import type { SideProps } from './types'
 
@@ -12,22 +11,14 @@ import type { SideProps } from './types'
  * smaller screens.
  * @summary Handles maximised and minimised transitions.
  */
-export const Side = ({
-  children,
-  style,
-  open,
-  minimised,
-  width = '20rem',
-}: SideProps) => {
-  const vars = { '--core-side-width': width } as CSSProperties
-
+export const Side = ({ children, style, open, minimised }: SideProps) => {
   const classses = classNames(classes.side, {
     [classes.sideHidden]: !open,
     [classes.sideMinimised]: minimised,
   })
 
   return (
-    <div style={{ ...vars, ...style }} className={classses}>
+    <div style={{ ...style }} className={classses}>
       {children}
     </div>
   )

--- a/packages/ui-core/src/base/Page/Side/types.ts
+++ b/packages/ui-core/src/base/Page/Side/types.ts
@@ -8,6 +8,4 @@ export type SideProps = ComponentBase & {
   open: boolean
   // Whether side menu is in minimised state.
   minimised: boolean
-  // Optional width property to be applied to maximised side.
-  width?: string | number
 }


### PR DESCRIPTION
Shrinks the maximised side menu to give more space to the main app content. Refactors props such as `action`, which is now simply `bullet`, and unified some styles.

The side menu, when hidden & toggle-able, retains its previous width of 195px.