### PR TITLE
Fix: Currency in modal order

### DIFF
--- a/packages/app/src/overlay/modals/SelectCurrency/index.tsx
+++ b/packages/app/src/overlay/modals/SelectCurrency/index.tsx
@@ -30,17 +30,24 @@ export const SelectCurrency = () => {
     setSearchTerm(e.target.value)
   }
 
-  const filteredCurrencies = Object.keys(SupportedCurrencies).filter((c) => {
-    const searchTermLower = searchTerm.toLowerCase()
-    const currencyName = t(`currencies.${c}.name`).toLowerCase()
-    const currencySymbol = SupportedCurrencies[c].symbol.toLowerCase()
-    const currencyCode = c.toLowerCase()
-    return (
-      currencyCode.includes(searchTermLower) ||
-      currencyName.includes(searchTermLower) ||
-      currencySymbol.includes(searchTermLower)
-    )
-  })
+  const filteredCurrencies = Object.keys(SupportedCurrencies)
+    .filter((c) => {
+      const searchTermLower = searchTerm.toLowerCase()
+      const currencyName = t(`currencies.${c}.name`).toLowerCase()
+      const currencySymbol = SupportedCurrencies[c].symbol.toLowerCase()
+      const currencyCode = c.toLowerCase()
+      return (
+        currencyCode.includes(searchTermLower) ||
+        currencyName.includes(searchTermLower) ||
+        currencySymbol.includes(searchTermLower)
+      )
+    })
+    .sort((a, b) => {
+      // Sort alphabetically based on the translated currency names
+      const nameA = t(`currencies.${a}.name`)
+      const nameB = t(`currencies.${b}.name`)
+      return nameA.localeCompare(nameB, undefined, { sensitivity: 'base' })
+    })
 
   useEffect(() => {
     setModalResize()


### PR DESCRIPTION
- Added sorting in the SelectCurrency modal to display currencies alphabetically based on translated names. Using localeCompare() with the user's current language settings ensures proper alphabetical ordering regardless of whether the interface is in English, Spanish, or Chinese.