### PR TITLE
feat(ux): use SimpleBar in Connect Container

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "react": "^18.3.1",
     "react-error-boundary": "^4.0.13",
     "react-i18next": "^15.4.0",
+    "simplebar": "^6.3.0",
+    "simplebar-react": "^3.3.0",
     "styled-components": "^6.1.13",
     "vitest": "^3.0.7"
   },

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -25,6 +25,8 @@
     "@fortawesome/free-solid-svg-icons": "*",
     "@w3ux/utils": "*",
     "radix-ui": "*",
-    "react": "*"
+    "react": "*",
+    "simplebar": "*",
+    "simplebar-react": "*"
   }
 }

--- a/packages/ui-core/src/popover/ConnectItem/Container/index.module.scss
+++ b/packages/ui-core/src/popover/ConnectItem/Container/index.module.scss
@@ -2,36 +2,28 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 .container {
-  > .scroll {
-    border-radius: 0.4rem;
-    overflow-y: scroll;
-    overflow-x: hidden;
-    position: relative;
-    max-height: 75vh;
+  .inner {
+    display: flex;
+    flex-flow: column wrap;
+    width: 100%;
 
-    > .inner {
-      display: flex;
-      flex-flow: column wrap;
-      width: 100%;
+    > h4 {
+      background: var(--button-popover-tab-background);
+      color: var(--text-color-tertiary);
+      font-family: InterSemiBold, sans-serif;
+      overflow: hidden;
+      padding: 0 0.75rem;
+      line-height: 3rem;
+    }
 
-      > h4 {
-        background: var(--button-popover-tab-background);
-        color: var(--text-color-tertiary);
-        font-family: InterSemiBold, sans-serif;
-        overflow: hidden;
-        padding: 0 0.75rem;
-        line-height: 3rem;
-      }
-
+    > section {
+      overflow: hidden;
       > section {
         overflow: hidden;
-        > section {
-          overflow: hidden;
-        }
+      }
 
-        &:last-child {
-          margin-bottom: 0;
-        }
+      &:last-child {
+        margin-bottom: 0;
       }
     }
   }

--- a/packages/ui-core/src/popover/ConnectItem/Container/index.tsx
+++ b/packages/ui-core/src/popover/ConnectItem/Container/index.tsx
@@ -3,12 +3,14 @@
 
 import type { ComponentBase } from '@w3ux/types'
 import { motion } from 'framer-motion'
+import SimpleBar from 'simplebar-react'
+import 'simplebar/dist/simplebar.min.css'
 import classes from './index.module.scss'
 
 export const Container = ({ style, children }: ComponentBase) => (
   <motion.div style={style} className={classes.container}>
-    <div className={classes.scroll}>
+    <SimpleBar style={{ maxHeight: '75vh' }} autoHide={true}>
       <div className={classes.inner}>{children}</div>
-    </div>
+    </SimpleBar>
   </motion.div>
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -8991,6 +8991,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+  languageName: node
+  linkType: hard
+
 "log-symbols@npm:^6.0.0":
   version: 6.0.0
   resolution: "log-symbols@npm:6.0.0"
@@ -10053,6 +10060,8 @@ __metadata:
     react-error-boundary: "npm:^4.0.13"
     react-i18next: "npm:^15.4.0"
     sass: "npm:1.77.6"
+    simplebar: "npm:^6.3.0"
+    simplebar-react: "npm:^3.3.0"
     styled-components: "npm:^6.1.13"
     typescript: "npm:^5.7.2"
     typescript-eslint: "npm:^8.25.0"
@@ -11312,6 +11321,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simplebar-core@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "simplebar-core@npm:1.3.0"
+  dependencies:
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/c8aa86a402e9a13ffb7a65d75851d400345f109f092f8c23c546bd3e451a7c63d84784fc3bb1c15283cd05ece2ccddd28025f42db0b50aa00db385d8afa7f5e6
+  languageName: node
+  linkType: hard
+
+"simplebar-react@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "simplebar-react@npm:3.3.0"
+  dependencies:
+    simplebar-core: "npm:^1.3.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10c0/ad07ac2b239f7372af48f92ad01b82a7e6465fcd1c43da9f5d12edb26cba81a55c87badd2cffac4aa8aa769da56c05b4e2eb5de19fec52588ca57f87d1f6202b
+  languageName: node
+  linkType: hard
+
+"simplebar@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "simplebar@npm:6.3.0"
+  dependencies:
+    simplebar-core: "npm:^1.3.0"
+  checksum: 10c0/e74f2637065d3f447124342b6223dbf7098966fff2c3185b62d056a38295c1b846496024d7ee4c3b17c0497dfd9c800d2231d3890c33e4e50ec0c53558872529
+  languageName: node
+  linkType: hard
+
 "smart-buffer@npm:^4.2.0":
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
@@ -12251,6 +12289,8 @@ __metadata:
     "@w3ux/utils": "*"
     radix-ui: "*"
     react: "*"
+    simplebar: "*"
+    simplebar-react: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Introduces `SimpleBar` to the codebase, adding it to the connect popover container, allowing a unified scroll bar style that automatically hides on all browsers and platforms. 

Prevents scroll bars from being displayed when external trackpads or mice are connected.