### PR TITLE
feat(ux): Button primary as label support

### DIFF
--- a/packages/ui-buttons/src/ButtonPrimary/index.tsx
+++ b/packages/ui-buttons/src/ButtonPrimary/index.tsx
@@ -35,6 +35,7 @@ export const ButtonPrimary = (props: ButtonPrimaryProps): JSX.Element => {
     onMouseOver,
     style,
     text,
+    asLabel,
   } = props
 
   const buttonClasses = classNames(
@@ -55,14 +56,8 @@ export const ButtonPrimary = (props: ButtonPrimaryProps): JSX.Element => {
     className
   )
 
-  return (
-    <button
-      className={buttonClasses}
-      style={style}
-      type="button"
-      disabled={disabled}
-      {...onMouseHandlers({ onClick, onMouseOver, onMouseMove, onMouseOut })}
-    >
+  const buttonContent = (
+    <>
       {iconLeft && (
         <FontAwesomeIcon
           icon={iconLeft}
@@ -78,6 +73,26 @@ export const ButtonPrimary = (props: ButtonPrimaryProps): JSX.Element => {
           transform={iconTransform}
         />
       )}
+    </>
+  )
+
+  if (asLabel) {
+    return (
+      <div className={buttonClasses} style={style}>
+        {buttonContent}
+      </div>
+    )
+  }
+
+  return (
+    <button
+      className={buttonClasses}
+      style={style}
+      type="button"
+      disabled={disabled}
+      {...onMouseHandlers({ onClick, onMouseOver, onMouseMove, onMouseOut })}
+    >
+      {buttonContent}
     </button>
   )
 }

--- a/packages/ui-buttons/src/types.ts
+++ b/packages/ui-buttons/src/types.ts
@@ -93,6 +93,7 @@ export type ButtonPrimaryProps = ComponentBaseWithClassName &
     colorSecondary?: boolean
     size?: ButtonSize
     text: string
+    asLabel?: boolean
   }
 
 export type ButtonPrimaryInvertProps = ComponentBaseWithClassName &


### PR DESCRIPTION
Adds an `asLabel` prop to `ButtonPrimary` to return it as a div element instead of a button. Required for embedding button components within a Popover.