### PR TITLE
fix: Minimum to earn rewards to be at least min nominator bond

### DIFF
--- a/packages/app/src/pages/Nominate/Active/Stats/MinimumActiveStake.tsx
+++ b/packages/app/src/pages/Nominate/Active/Stats/MinimumActiveStake.tsx
@@ -1,6 +1,7 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import BigNumber from 'bignumber.js'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { Number } from 'library/StatCards/Number'
@@ -13,10 +14,13 @@ export const MinimumActiveStake = () => {
     networkData: { unit, units },
   } = useNetwork()
   const { minimumActiveStake } = useApi().networkMetrics
+  const { minNominatorBond } = useApi().stakingMetrics
+
+  const minToEarnRewards = BigNumber.max(minNominatorBond, minimumActiveStake)
 
   const params = {
     label: t('minimumToEarnRewards'),
-    value: planckToUnitBn(minimumActiveStake, units).toNumber(),
+    value: planckToUnitBn(minToEarnRewards, units).toNumber(),
     decimals: 3,
     unit: `${unit}`,
     helpKey: 'Bonding',


### PR DESCRIPTION
Amends the minimum to earn rewards stat to be at least the minimum nominator bond.