### PR TITLE
feat: Add AssetHub chains to `dedot-api` default services

### DIFF
--- a/packages/consts/src/networks.ts
+++ b/packages/consts/src/networks.ts
@@ -15,7 +15,6 @@ export const NetworkList: Networks = {
       rpc: {
         'Automata 1RPC': 'wss://1rpc.io/dot',
         Dwellir: 'wss://polkadot-rpc.dwellir.com',
-        'Dwellir Tunisia': 'wss://polkadot-rpc-tn.dwellir.com',
         'IBP-GeoDNS1': 'wss://rpc.ibp.network/polkadot',
         'IBP-GeoDNS2': 'wss://rpc.dotters.network/polkadot',
         LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
@@ -36,7 +35,6 @@ export const NetworkList: Networks = {
       rpc: {
         'Automata 1RPC': 'wss://1rpc.io/ksm',
         Dwellir: 'wss://kusama-rpc.dwellir.com',
-        'Dwellir Tunisia': 'wss://kusama-rpc-tn.dwellir.com',
         'IBP-GeoDNS1': 'wss://rpc.ibp.network/kusama',
         'IBP-GeoDNS2': 'wss://rpc.dotters.network/kusama',
         LuckyFriday: 'wss://rpc-kusama.luckyfriday.io',
@@ -56,7 +54,6 @@ export const NetworkList: Networks = {
       defaultRpc: 'IBP-GeoDNS1',
       rpc: {
         Dwellir: 'wss://westend-rpc.dwellir.com',
-        'Dwellir Tunisia': 'wss://westend-rpc-tn.dwellir.com',
         'IBP-GeoDNS1': 'wss://rpc.ibp.network/westend',
         'IBP-GeoDNS2': 'wss://rpc.dotters.network/westend',
         LuckyFriday: 'wss://rpc-westend.luckyfriday.io',
@@ -129,7 +126,6 @@ export const SystemChainList: Record<string, SystemChain> = {
         await import('@substrate/connect-known-chains/polkadot_asset_hub'),
       defaultRpc: 'IBP1',
       rpc: {
-        'Dwellir Tunisia': 'wss://statemint-rpc-tn.dwellir.com',
         'Lucky Friday': 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
         Parity: 'wss://polkadot-asset-hub-rpc.polkadot.io',
         StakeWorld: 'wss://dot-rpc.stakeworld.io/assethub',
@@ -150,8 +146,6 @@ export const SystemChainList: Record<string, SystemChain> = {
         await import('@substrate/connect-known-chains/ksmcc3_asset_hub'),
       defaultRpc: 'IBP1',
       rpc: {
-        Dwellir: 'wss://statemine-rpc.dwellir.com',
-        'Dwellir Tunisia': 'wss://statemine-rpc-tn.dwellir.com',
         'Lucky Friday': 'wss://rpc-asset-hub-kusama.luckyfriday.io',
         Parity: 'wss://kusama-asset-hub-rpc.polkadot.io',
         IBP1: 'wss://sys.ibp.network/asset-hub-kusama',
@@ -160,8 +154,8 @@ export const SystemChainList: Record<string, SystemChain> = {
     },
     relayChain: 'kusama',
   },
-  westend_assethub: {
-    name: 'westend_assethub',
+  westmint: {
+    name: 'westmint',
     ss58: 42,
     units: 12,
     unit: 'WND',
@@ -172,7 +166,6 @@ export const SystemChainList: Record<string, SystemChain> = {
       rpc: {
         Parity: 'wss://westend-asset-hub-rpc.polkadot.io',
         Dwellir: 'wss://asset-hub-westend-rpc.dwellir.com',
-        'Dwellir Tunisia': 'wss://westmint-rpc-tn.dwellir.com',
         IBP1: 'wss://sys.ibp.network/asset-hub-westend',
         IBP2: 'wss://asset-hub-westend.dotters.network',
         'Permanence DAO EU': 'wss://asset-hub-westend.rpc.permanence.io',

--- a/packages/consts/src/networks.ts
+++ b/packages/consts/src/networks.ts
@@ -9,7 +9,6 @@ export const NetworkList: Networks = {
   polkadot: {
     name: 'polkadot',
     endpoints: {
-      lightClientKey: 'polkadot',
       lightClient: async () =>
         await import('@substrate/connect-known-chains/polkadot'),
       defaultRpc: 'IBP-GeoDNS1',
@@ -31,7 +30,6 @@ export const NetworkList: Networks = {
   kusama: {
     name: 'kusama',
     endpoints: {
-      lightClientKey: 'ksmcc3',
       lightClient: async () =>
         await import('@substrate/connect-known-chains/ksmcc3'),
       defaultRpc: 'IBP-GeoDNS1',
@@ -53,7 +51,6 @@ export const NetworkList: Networks = {
   westend: {
     name: 'westend',
     endpoints: {
-      lightClientKey: 'westend2',
       lightClient: async () =>
         await import('@substrate/connect-known-chains/westend2'),
       defaultRpc: 'IBP-GeoDNS1',
@@ -80,7 +77,6 @@ export const SystemChainList: Record<string, SystemChain> = {
     units: 10,
     unit: 'DOT',
     endpoints: {
-      lightClientKey: 'polkadot_people',
       lightClient: async () =>
         await import('@substrate/connect-known-chains/polkadot_people'),
       defaultRpc: 'IBP1',
@@ -97,7 +93,6 @@ export const SystemChainList: Record<string, SystemChain> = {
     units: 12,
     unit: 'KSM',
     endpoints: {
-      lightClientKey: 'ksmcc3_people',
       lightClient: async () =>
         await import('@substrate/connect-known-chains/ksmcc3_people'),
       defaultRpc: 'IBP1',
@@ -114,13 +109,73 @@ export const SystemChainList: Record<string, SystemChain> = {
     units: 12,
     unit: 'WND',
     endpoints: {
-      lightClientKey: 'westend2_people',
       lightClient: async () =>
         await import('@substrate/connect-known-chains/westend_people'),
       defaultRpc: 'IBP1',
       rpc: {
         IBP1: 'wss://sys.ibp.network/people-westend',
         IBP2: 'wss://people-westend.dotters.network',
+      },
+    },
+    relayChain: 'westend',
+  },
+  statemint: {
+    name: 'statemint',
+    ss58: 0,
+    units: 10,
+    unit: 'DOT',
+    endpoints: {
+      lightClient: async () =>
+        await import('@substrate/connect-known-chains/polkadot_asset_hub'),
+      defaultRpc: 'IBP1',
+      rpc: {
+        'Dwellir Tunisia': 'wss://statemint-rpc-tn.dwellir.com',
+        'Lucky Friday': 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
+        Parity: 'wss://polkadot-asset-hub-rpc.polkadot.io',
+        StakeWorld: 'wss://dot-rpc.stakeworld.io/assethub',
+        Dwellir: 'wss://asset-hub-polkadot-rpc.dwellir.com',
+        IBP1: 'wss://sys.ibp.network/asset-hub-polkadot',
+        IBP2: 'wss://asset-hub-polkadot.dotters.network',
+      },
+    },
+    relayChain: 'polkadot',
+  },
+  statemine: {
+    name: 'statemine',
+    ss58: 2,
+    units: 12,
+    unit: 'KSM',
+    endpoints: {
+      lightClient: async () =>
+        await import('@substrate/connect-known-chains/ksmcc3_asset_hub'),
+      defaultRpc: 'IBP1',
+      rpc: {
+        Dwellir: 'wss://statemine-rpc.dwellir.com',
+        'Dwellir Tunisia': 'wss://statemine-rpc-tn.dwellir.com',
+        'Lucky Friday': 'wss://rpc-asset-hub-kusama.luckyfriday.io',
+        Parity: 'wss://kusama-asset-hub-rpc.polkadot.io',
+        IBP1: 'wss://sys.ibp.network/asset-hub-kusama',
+        IBP2: 'wss://asset-hub-kusama.dotters.network',
+      },
+    },
+    relayChain: 'kusama',
+  },
+  westend_assethub: {
+    name: 'westend_assethub',
+    ss58: 42,
+    units: 12,
+    unit: 'WND',
+    endpoints: {
+      lightClient: async () =>
+        await import('@substrate/connect-known-chains/westend2_asset_hub'),
+      defaultRpc: 'IBP1',
+      rpc: {
+        Parity: 'wss://westend-asset-hub-rpc.polkadot.io',
+        Dwellir: 'wss://asset-hub-westend-rpc.dwellir.com',
+        'Dwellir Tunisia': 'wss://westmint-rpc-tn.dwellir.com',
+        IBP1: 'wss://sys.ibp.network/asset-hub-westend',
+        IBP2: 'wss://asset-hub-westend.dotters.network',
+        'Permanence DAO EU': 'wss://asset-hub-westend.rpc.permanence.io',
       },
     },
     relayChain: 'westend',

--- a/packages/consts/src/util.ts
+++ b/packages/consts/src/util.ts
@@ -59,3 +59,14 @@ export const getDefaultRpcEndpoints = (network: NetworkId) => {
     ...systemChainRpc,
   }
 }
+
+// Get asset hub chain id from network id
+export const getHubChainId = (network: NetworkId) => {
+  if (network === 'westend') {
+    return 'westmint'
+  }
+  if (network === 'kusama') {
+    return 'statemine'
+  }
+  return 'statemint'
+}

--- a/packages/dedot-api/src/services/polkadot.ts
+++ b/packages/dedot-api/src/services/polkadot.ts
@@ -141,7 +141,7 @@ export class PolkadotService
     setMultiChainSpecs({
       [this.ids[0]]: this.relayChainSpec.get(),
       [this.ids[1]]: this.peopleChainSpec.get(),
-      [this.ids[1]]: this.hubChainSpec.get(),
+      [this.ids[2]]: this.hubChainSpec.get(),
     })
     setConsts(this.ids[0], {
       ...this.coreConsts.get(),

--- a/packages/dedot-api/src/services/polkadot.ts
+++ b/packages/dedot-api/src/services/polkadot.ts
@@ -1,6 +1,7 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { PolkadotAssetHubApi } from '@dedot/chaintypes'
 import type { PolkadotApi } from '@dedot/chaintypes/polkadot'
 import type { PolkadotPeopleApi } from '@dedot/chaintypes/polkadot-people'
 import { formatAccountSs58 } from '@w3ux/utils'
@@ -55,13 +56,22 @@ import {
 } from '../util'
 
 export class PolkadotService
-  implements DefaultServiceClass<PolkadotApi, PolkadotPeopleApi, PolkadotApi>
+  implements
+    DefaultServiceClass<
+      PolkadotApi,
+      PolkadotPeopleApi,
+      PolkadotAssetHubApi,
+      PolkadotApi
+    >
 {
   relayChainSpec: ChainSpecs<PolkadotApi>
   peopleChainSpec: ChainSpecs<PolkadotPeopleApi>
+  hubChainSpec: ChainSpecs<PolkadotAssetHubApi>
+
   apiStatus: {
     relay: ApiStatus<PolkadotApi>
     people: ApiStatus<PolkadotPeopleApi>
+    hub: ApiStatus<PolkadotAssetHubApi>
   }
   coreConsts: CoreConsts<PolkadotApi>
   stakingConsts: StakingConsts<PolkadotApi>
@@ -77,9 +87,14 @@ export class PolkadotService
   subActiveAddress: Subscription
   subImportedAccounts: Subscription
   subActiveEra: Subscription
-  subAccountBalances: AccountBalances<PolkadotApi, PolkadotPeopleApi> = {
+  subAccountBalances: AccountBalances<
+    PolkadotApi,
+    PolkadotPeopleApi,
+    PolkadotAssetHubApi
+  > = {
     relay: {},
     people: {},
+    hub: {},
   }
   subStakingLedgers: StakingLedgers<PolkadotApi> = {}
   subProxies: Proxies<PolkadotApi> = {}
@@ -88,41 +103,45 @@ export class PolkadotService
 
   constructor(
     public networkConfig: NetworkConfig,
-    public ids: [NetworkId, SystemChainId],
+    public ids: [NetworkId, SystemChainId, SystemChainId],
     public apiRelay: DedotClient<PolkadotApi>,
-    public apiPeople: DedotClient<PolkadotPeopleApi>
+    public apiPeople: DedotClient<PolkadotPeopleApi>,
+    public apiHub: DedotClient<PolkadotAssetHubApi>
   ) {
-    this.ids = ids
-    this.apiRelay = apiRelay
-    this.apiPeople = apiPeople
-    this.networkConfig = networkConfig
     this.apiStatus = {
       relay: new ApiStatus(this.apiRelay, ids[0], networkConfig),
       people: new ApiStatus(this.apiPeople, ids[1], networkConfig),
+      hub: new ApiStatus(this.apiHub, ids[2], networkConfig),
     }
   }
 
   getApi = (id: string) => {
     if (id === this.ids[0]) {
       return this.apiRelay
-    } else {
+    } else if (id === this.ids[1]) {
       return this.apiPeople
+    } else {
+      return this.apiHub
     }
   }
 
   start = async () => {
     this.relayChainSpec = new ChainSpecs(this.apiRelay)
     this.peopleChainSpec = new ChainSpecs(this.apiPeople)
+    this.hubChainSpec = new ChainSpecs(this.apiHub)
+
     this.coreConsts = new CoreConsts(this.apiRelay)
     this.stakingConsts = new StakingConsts(this.apiRelay)
 
     await Promise.all([
       this.relayChainSpec.fetch(),
       this.peopleChainSpec.fetch(),
+      this.hubChainSpec.fetch(),
     ])
     setMultiChainSpecs({
       [this.ids[0]]: this.relayChainSpec.get(),
       [this.ids[1]]: this.peopleChainSpec.get(),
+      [this.ids[1]]: this.hubChainSpec.get(),
     })
     setConsts(this.ids[0], {
       ...this.coreConsts.get(),
@@ -183,6 +202,8 @@ export class PolkadotService
           new AccountBalanceQuery(this.apiRelay, this.ids[0], account.address)
         this.subAccountBalances['people'][getAccountKey(this.ids[1], account)] =
           new AccountBalanceQuery(this.apiPeople, this.ids[1], account.address)
+        this.subAccountBalances['hub'][getAccountKey(this.ids[2], account)] =
+          new AccountBalanceQuery(this.apiHub, this.ids[2], account.address)
 
         this.subStakingLedgers[account.address] = new StakingLedgerQuery(
           this.apiRelay,
@@ -242,7 +263,11 @@ export class PolkadotService
     this.eraRewardPoints?.unsubscribe()
     this.fastUnstakeQueue?.unsubscribe()
 
-    await Promise.all([this.apiRelay.disconnect(), this.apiPeople.disconnect()])
+    await Promise.all([
+      this.apiRelay.disconnect(),
+      this.apiPeople.disconnect(),
+      this.apiHub.disconnect(),
+    ])
   }
 
   interface: ServiceInterface = {

--- a/packages/dedot-api/src/services/westend.ts
+++ b/packages/dedot-api/src/services/westend.ts
@@ -1,6 +1,7 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { WestendAssetHubApi } from '@dedot/chaintypes'
 import type { WestendApi } from '@dedot/chaintypes/westend'
 import type { WestendPeopleApi } from '@dedot/chaintypes/westend-people'
 import { ExtraSignedExtension, type DedotClient } from 'dedot'
@@ -54,13 +55,22 @@ import {
 } from '../util'
 
 export class WestendService
-  implements DefaultServiceClass<WestendApi, WestendPeopleApi, WestendApi>
+  implements
+    DefaultServiceClass<
+      WestendApi,
+      WestendPeopleApi,
+      WestendAssetHubApi,
+      WestendApi
+    >
 {
   relayChainSpec: ChainSpecs<WestendApi>
   peopleChainSpec: ChainSpecs<WestendPeopleApi>
+  hubChainSpec: ChainSpecs<WestendAssetHubApi>
+
   apiStatus: {
     relay: ApiStatus<WestendApi>
     people: ApiStatus<WestendPeopleApi>
+    hub: ApiStatus<WestendAssetHubApi>
   }
   coreConsts: CoreConsts<WestendApi>
   stakingConsts: StakingConsts<WestendApi>
@@ -76,9 +86,14 @@ export class WestendService
   subActiveAddress: Subscription
   subActiveEra: Subscription
   subImportedAccounts: Subscription
-  subAccountBalances: AccountBalances<WestendApi, WestendPeopleApi> = {
+  subAccountBalances: AccountBalances<
+    WestendApi,
+    WestendPeopleApi,
+    WestendAssetHubApi
+  > = {
     relay: {},
     people: {},
+    hub: {},
   }
   subStakingLedgers: StakingLedgers<WestendApi> = {}
   subProxies: Proxies<WestendApi> = {}
@@ -87,41 +102,44 @@ export class WestendService
 
   constructor(
     public networkConfig: NetworkConfig,
-    public ids: [NetworkId, SystemChainId],
+    public ids: [NetworkId, SystemChainId, SystemChainId],
     public apiRelay: DedotClient<WestendApi>,
-    public apiPeople: DedotClient<WestendPeopleApi>
+    public apiPeople: DedotClient<WestendPeopleApi>,
+    public apiHub: DedotClient<WestendAssetHubApi>
   ) {
-    this.ids = ids
-    this.apiRelay = apiRelay
-    this.apiPeople = apiPeople
-    this.networkConfig = networkConfig
     this.apiStatus = {
       relay: new ApiStatus(this.apiRelay, ids[0], networkConfig),
       people: new ApiStatus(this.apiPeople, ids[1], networkConfig),
+      hub: new ApiStatus(this.apiHub, ids[2], networkConfig),
     }
   }
-
   getApi = (id: string) => {
     if (id === this.ids[0]) {
       return this.apiRelay
-    } else {
+    } else if (id === this.ids[1]) {
       return this.apiPeople
+    } else {
+      return this.apiHub
     }
   }
 
   start = async () => {
     this.relayChainSpec = new ChainSpecs(this.apiRelay)
     this.peopleChainSpec = new ChainSpecs(this.apiPeople)
+    this.hubChainSpec = new ChainSpecs(this.apiHub)
+
     this.coreConsts = new CoreConsts(this.apiRelay)
     this.stakingConsts = new StakingConsts(this.apiRelay)
 
     await Promise.all([
       this.relayChainSpec.fetch(),
       this.peopleChainSpec.fetch(),
+      this.hubChainSpec.fetch(),
     ])
     setMultiChainSpecs({
       [this.ids[0]]: this.relayChainSpec.get(),
       [this.ids[1]]: this.peopleChainSpec.get(),
+      [this.ids[2]]: this.hubChainSpec.get(),
     })
     setConsts(this.ids[0], {
       ...this.coreConsts.get(),
@@ -175,6 +193,8 @@ export class WestendService
           new AccountBalanceQuery(this.apiRelay, this.ids[0], account.address)
         this.subAccountBalances['people'][getAccountKey(this.ids[1], account)] =
           new AccountBalanceQuery(this.apiPeople, this.ids[1], account.address)
+        this.subAccountBalances['hub'][getAccountKey(this.ids[2], account)] =
+          new AccountBalanceQuery(this.apiHub, this.ids[2], account.address)
 
         this.subStakingLedgers[account.address] = new StakingLedgerQuery(
           this.apiRelay,
@@ -234,7 +254,11 @@ export class WestendService
     this.eraRewardPoints?.unsubscribe()
     this.fastUnstakeQueue?.unsubscribe()
 
-    await Promise.all([this.apiRelay.disconnect(), this.apiPeople.disconnect()])
+    await Promise.all([
+      this.apiRelay.disconnect(),
+      this.apiPeople.disconnect(),
+      this.apiHub.disconnect(),
+    ])
   }
 
   interface: ServiceInterface = {

--- a/packages/dedot-api/src/start.ts
+++ b/packages/dedot-api/src/start.ts
@@ -1,7 +1,7 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { getNetworkData, getSystemChainData } from 'consts/util'
+import { getHubChainId, getNetworkData, getSystemChainData } from 'consts/util'
 import { DedotClient, WsProvider } from 'dedot'
 import { setMultiApiStatus } from 'global-bus'
 import type { NetworkConfig, NetworkId, SystemChainId } from 'types'
@@ -18,11 +18,18 @@ export const getDefaultService = async <T extends NetworkId>(
   network: T,
   { rpcEndpoints, providerType }: Omit<NetworkConfig, 'network'>
 ): Promise<DefaultService<T>> => {
+  const peopleChainId: SystemChainId = `people-${network}`
+  const hubChainId: SystemChainId = getHubChainId(network)
+
   const relayData = getNetworkData(network)
   const peopleData = getSystemChainData(`people-${network}`)
-  const peopleChainId: SystemChainId = `people-${network}`
+  const hubData = getSystemChainData(hubChainId)
 
-  const ids = [network, peopleChainId] as [NetworkId, SystemChainId]
+  const ids = [network, peopleChainId, hubChainId] as [
+    NetworkId,
+    SystemChainId,
+    SystemChainId,
+  ]
 
   const relayProvider =
     providerType === 'ws'
@@ -34,24 +41,32 @@ export const getDefaultService = async <T extends NetworkId>(
       ? new WsProvider(peopleData.endpoints.rpc[rpcEndpoints[peopleChainId]])
       : await newSystemChainSmProvider(relayData, peopleData)
 
+  const hubProvider =
+    providerType === 'ws'
+      ? new WsProvider(hubData.endpoints.rpc[rpcEndpoints[hubChainId]])
+      : await newSystemChainSmProvider(relayData, hubData)
+
   setMultiApiStatus({
     [network]: 'connecting',
     [peopleChainId]: 'connecting',
+    [hubChainId]: 'connecting',
   })
 
-  const [apiRelay, apiPeople] = await Promise.all([
+  const [apiRelay, apiPeople, apiHub] = await Promise.all([
     DedotClient.new<Service[T][0]>(relayProvider),
     DedotClient.new<Service[T][1]>(peopleProvider),
+    DedotClient.new<Service[T][2]>(hubProvider),
   ])
 
   setMultiApiStatus({
     [network]: 'ready',
     [peopleChainId]: 'ready',
+    [hubChainId]: 'ready',
   })
 
   return {
     Service: Services[network],
-    apis: [apiRelay, apiPeople],
+    apis: [apiRelay, apiPeople, apiHub],
     ids,
   }
 }

--- a/packages/dedot-api/src/types/index.ts
+++ b/packages/dedot-api/src/types/index.ts
@@ -1,14 +1,13 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type {
-  KusamaApi,
-  PolkadotApi,
-  WestendApi,
-  WestendPeopleApi,
-} from '@dedot/chaintypes'
+import type { KusamaApi, PolkadotApi, WestendApi } from '@dedot/chaintypes'
+import type { KusamaAssetHubApi } from '@dedot/chaintypes/kusama-asset-hub'
 import type { KusamaPeopleApi } from '@dedot/chaintypes/kusama-people'
+import type { PolkadotAssetHubApi } from '@dedot/chaintypes/polkadot-asset-hub'
 import type { PolkadotPeopleApi } from '@dedot/chaintypes/polkadot-people'
+import type { WestendAssetHubApi } from '@dedot/chaintypes/westend-asset-hub'
+import type { WestendPeopleApi } from '@dedot/chaintypes/westend-people'
 import type { ServiceInterface } from 'types'
 import type { KusamaService } from '../services/kusama'
 import type { PolkadotService } from '../services/polkadot'
@@ -18,16 +17,25 @@ import type { WestendService } from '../services/westend'
 export type Chain =
   | PolkadotApi
   | PolkadotPeopleApi
+  | PolkadotAssetHubApi
   | KusamaApi
   | KusamaPeopleApi
+  | KusamaAssetHubApi
   | WestendApi
   | WestendPeopleApi
+  | WestendAssetHubApi
 
 // Relay chains
 export type RelayChain = PolkadotApi | KusamaApi | WestendApi
 
 // People chains
 export type PeopleChain = PolkadotPeopleApi | KusamaPeopleApi | WestendPeopleApi
+
+// Asset hub chains
+export type AssetHubChain =
+  | PolkadotAssetHubApi
+  | KusamaAssetHubApi
+  | WestendAssetHubApi
 
 // Chains that are used for staking and nomination pools
 export type StakingChain = PolkadotApi | KusamaApi | WestendApi
@@ -41,9 +49,9 @@ export interface ServiceType {
 
 // Mapping of the required chains for each service
 export type Service = {
-  polkadot: [PolkadotApi, PolkadotPeopleApi]
-  kusama: [KusamaApi, KusamaPeopleApi]
-  westend: [WestendApi, WestendPeopleApi]
+  polkadot: [PolkadotApi, PolkadotPeopleApi, PolkadotAssetHubApi]
+  kusama: [KusamaApi, KusamaPeopleApi, KusamaAssetHubApi]
+  westend: [WestendApi, WestendPeopleApi, WestendAssetHubApi]
 }
 
 // Generic service class that all services must implement

--- a/packages/dedot-api/src/types/serviceDefault.ts
+++ b/packages/dedot-api/src/types/serviceDefault.ts
@@ -9,14 +9,15 @@ import type {
   ServiceInterface,
   SystemChainId,
 } from 'types'
-import {
-  ServiceClass,
-  type PeopleChain,
-  type RelayChain,
-  type Service,
-  type ServiceType,
-  type StakingChain,
+import type {
+  AssetHubChain,
+  PeopleChain,
+  RelayChain,
+  Service,
+  ServiceType,
+  StakingChain,
 } from '.'
+import { ServiceClass } from '.'
 import type { CoreConsts } from '../consts/core'
 import type { StakingConsts } from '../consts/staking'
 import type { ApiStatus } from '../spec/apiStatus'
@@ -38,26 +39,31 @@ import type { StakingMetricsQuery } from '../subscribe/stakingMetrics'
 export abstract class DefaultServiceClass<
   RelayApi extends RelayChain,
   PeopleApi extends PeopleChain,
+  HubApi extends AssetHubChain,
   StakingApi extends StakingChain,
 > extends ServiceClass {
   constructor(
     public networkConfig: NetworkConfig,
     public apiRelay: DedotClient<RelayApi>,
-    public apiPeople: DedotClient<PeopleApi>
+    public apiPeople: DedotClient<PeopleApi>,
+    public apiHub: DedotClient<HubApi>
   ) {
     super()
   }
-  abstract ids: [NetworkId, SystemChainId]
+  abstract ids: [NetworkId, SystemChainId, SystemChainId]
   abstract apiStatus: {
     relay: ApiStatus<RelayApi>
     people: ApiStatus<PeopleApi>
+    hub: ApiStatus<HubApi>
   }
   abstract getApi: (
     id: string
-  ) => DedotClient<RelayApi> | DedotClient<PeopleApi>
+  ) => DedotClient<RelayApi> | DedotClient<PeopleApi> | DedotClient<HubApi>
 
   abstract relayChainSpec: ChainSpecs<RelayApi>
   abstract peopleChainSpec: ChainSpecs<PeopleApi>
+  abstract hubChainSpec: ChainSpecs<HubApi>
+
   abstract coreConsts: CoreConsts<RelayApi>
   abstract stakingConsts: StakingConsts<StakingApi>
   abstract blockNumber: BlockNumberQuery<RelayApi>
@@ -72,7 +78,7 @@ export abstract class DefaultServiceClass<
   subActiveAddress: Subscription
   subImportedAccounts: Subscription
   subActiveEra: Subscription
-  subAccountBalances: AccountBalances<RelayApi, PeopleApi>
+  subAccountBalances: AccountBalances<RelayApi, PeopleApi, HubApi>
   subStakingLedgers: StakingLedgers<StakingApi>
   subActivePoolIds: Subscription
   subActivePools: ActivePools<StakingApi>
@@ -84,17 +90,23 @@ export abstract class DefaultServiceClass<
 // Default interface a default service factory returns
 export type DefaultService<T extends keyof ServiceType> = {
   Service: ServiceType[T]
-  apis: [DedotClient<Service[T][0]>, DedotClient<Service[T][1]>]
-  ids: [NetworkId, SystemChainId]
+  apis: [
+    DedotClient<Service[T][0]>,
+    DedotClient<Service[T][1]>,
+    DedotClient<Service[T][2]>,
+  ]
+  ids: [NetworkId, SystemChainId, SystemChainId]
 }
 
 // Account balances record
 export type AccountBalances<
   RelayApi extends RelayChain,
   PeopleApi extends PeopleChain,
+  HubApi extends AssetHubChain,
 > = {
   relay: Record<string, AccountBalanceQuery<RelayApi>>
   people: Record<string, AccountBalanceQuery<PeopleApi>>
+  hub: Record<string, AccountBalanceQuery<HubApi>>
 }
 
 // Staking ledgers record

--- a/packages/global-bus/src/networkConfig/util.ts
+++ b/packages/global-bus/src/networkConfig/util.ts
@@ -3,7 +3,7 @@
 
 import { extractUrlValue, localStorageOrDefault } from '@w3ux/utils'
 import { NetworkKey, ProviderTypeKey, rpcEndpointKey } from 'consts'
-import { DefaultNetwork, NetworkList } from 'consts/networks'
+import { DefaultNetwork, NetworkList, SystemChainList } from 'consts/networks'
 import { getDefaultRpcEndpoints } from 'consts/util'
 import type {
   NetworkConfig,
@@ -43,11 +43,20 @@ export const getInitialNetwork = () => {
 
 export const getInitialRpcEndpoints = (network: NetworkId): RpcEndpoints => {
   // Validates local RPC endpoints by checking against the default values
-  const validateRpcEndpoints = (a: object, b: object) =>
-    JSON.stringify(Object.keys(a).sort()) ===
-      JSON.stringify(Object.keys(b).sort()) &&
-    Object.values(a).every((v) => typeof v === 'string') &&
-    Object.values(b).every((v) => typeof v === 'string')
+  const validateRpcEndpoints = (a: object, b: object) => {
+    const typeCheck =
+      JSON.stringify(Object.keys(a).sort()) ===
+        JSON.stringify(Object.keys(b).sort()) &&
+      Object.values(a).every((v) => typeof v === 'string') &&
+      Object.values(b).every((v) => typeof v === 'string')
+    // Check if values are valid RPC keys
+    const valueCheck = Object.entries(a).every(([k, v]) =>
+      Object.keys(
+        { ...NetworkList, ...SystemChainList }[k]?.endpoints?.rpc || []
+      ).includes(v)
+    )
+    return typeCheck && valueCheck
+  }
 
   const local = localStorageOrDefault<RpcEndpoints>(
     rpcEndpointKey(network),

--- a/packages/types/src/networks.ts
+++ b/packages/types/src/networks.ts
@@ -97,7 +97,6 @@ export interface NetworkConfig {
 export interface Network {
   name: NetworkId
   endpoints: {
-    lightClientKey: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     lightClient: () => Promise<any>
     defaultRpc: string
@@ -115,7 +114,6 @@ export interface SystemChain {
   units: number
   unit: string
   endpoints: {
-    lightClientKey: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     lightClient: () => Promise<any>
     defaultRpc: string

--- a/packages/types/src/networks.ts
+++ b/packages/types/src/networks.ts
@@ -13,6 +13,9 @@ export type SystemChainId =
   | 'people-polkadot'
   | 'people-kusama'
   | 'people-westend'
+  | 'statemint'
+  | 'statemine'
+  | 'westmint'
 
 export type ProviderType = 'ws' | 'sc'
 


### PR DESCRIPTION
Adds support for Asset Hub chains on Polkadot, Kusama and Westend. Services now connect to the hub as an additional chain, and populates metadata like chain specs and imported account balances from the chain.