### PR TITLE
feat: Disable Westend in production - Prep for AssetHub Migration

### DIFF
--- a/packages/app/src/contexts/Network/index.tsx
+++ b/packages/app/src/contexts/Network/index.tsx
@@ -3,6 +3,7 @@
 
 import { createSafeContext } from '@w3ux/hooks'
 import { varToUrlHash } from '@w3ux/utils'
+import { isNetworkEnabled } from 'consts/util'
 import {
   getNetwork,
   getProviderType,
@@ -24,8 +25,10 @@ export const NetworkProvider = ({ children }: { children: ReactNode }) => {
 
   // handle network switching
   const switchNetwork = async (name: NetworkId): Promise<void> => {
-    setNetworkConfig(name, getInitialRpcEndpoints(name), getProviderType())
-    varToUrlHash('n', name, false)
+    if (isNetworkEnabled(name)) {
+      setNetworkConfig(name, getInitialRpcEndpoints(name), getProviderType())
+      varToUrlHash('n', name, false)
+    }
   }
 
   // Subscribe to global bus network changes

--- a/packages/app/src/overlay/modals/Networks/index.tsx
+++ b/packages/app/src/overlay/modals/Networks/index.tsx
@@ -5,7 +5,7 @@ import { faChevronRight, faGlobe } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { capitalizeFirstLetter } from '@w3ux/utils'
 import { getChainIcons } from 'assets'
-import { NetworkList } from 'consts/networks'
+import { getEnabledNetworks } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { usePrompt } from 'contexts/Prompt'
@@ -47,40 +47,42 @@ export const Networks = () => {
         <ContentWrapper>
           <h4>{t('selectNetwork')}</h4>
           <div className="items">
-            {Object.entries(NetworkList).map(([key, item], index: number) => {
-              const inline = getChainIcons(key as NetworkId).inline
-              const Svg = inline.svg
-              const rpcDisabled = networkKey === key
+            {Object.entries(getEnabledNetworks()).map(
+              ([key, item], index: number) => {
+                const inline = getChainIcons(key as NetworkId).inline
+                const Svg = inline.svg
+                const rpcDisabled = networkKey === key
 
-              return (
-                <NetworkButton
-                  $connected={networkKey === key}
-                  disabled={rpcDisabled}
-                  key={`network_switch_${index}`}
-                  type="button"
-                  onClick={() => {
-                    if (networkKey !== key) {
-                      switchNetwork(key as NetworkId)
-                      setModalStatus('closing')
-                    }
-                  }}
-                >
-                  <div style={{ width: '1.75rem' }}>
-                    <Svg width={inline.size} height={inline.size} />
-                  </div>
-                  <h3>{capitalizeFirstLetter(item.name)}</h3>
-                  {networkKey === key && (
-                    <h4 className="selected">{t('selected')}</h4>
-                  )}
-                  <div>
-                    <FontAwesomeIcon
-                      transform="shrink-2"
-                      icon={faChevronRight}
-                    />
-                  </div>
-                </NetworkButton>
-              )
-            })}
+                return (
+                  <NetworkButton
+                    $connected={networkKey === key}
+                    disabled={rpcDisabled}
+                    key={`network_switch_${index}`}
+                    type="button"
+                    onClick={() => {
+                      if (networkKey !== key) {
+                        switchNetwork(key as NetworkId)
+                        setModalStatus('closing')
+                      }
+                    }}
+                  >
+                    <div style={{ width: '1.75rem' }}>
+                      <Svg width={inline.size} height={inline.size} />
+                    </div>
+                    <h3>{capitalizeFirstLetter(item.name)}</h3>
+                    {networkKey === key && (
+                      <h4 className="selected">{t('selected')}</h4>
+                    )}
+                    <div>
+                      <FontAwesomeIcon
+                        transform="shrink-2"
+                        icon={faChevronRight}
+                      />
+                    </div>
+                  </NetworkButton>
+                )
+              }
+            )}
           </div>
           <h4>{t('providerType')}</h4>
           <ConnectionsWrapper>

--- a/packages/consts/package.json
+++ b/packages/consts/package.json
@@ -15,6 +15,7 @@
     "assets": "workspace:*"
   },
   "devDependencies": {
-    "types": "workspace:*"
+    "types": "workspace:*",
+    "vite": "^6.3.5"
   }
 }

--- a/packages/consts/src/networks.ts
+++ b/packages/consts/src/networks.ts
@@ -3,8 +3,13 @@
 
 import type { NetworkId, Networks, SystemChain } from 'types'
 
+// The default network to use when no network is specified
 export const DefaultNetwork: NetworkId = 'polkadot'
 
+// Networks that are disabled in production
+export const ProductionDisabledNetworks: NetworkId[] = ['westend']
+
+// All supported networks
 export const NetworkList: Networks = {
   polkadot: {
     name: 'polkadot',
@@ -67,6 +72,7 @@ export const NetworkList: Networks = {
   },
 }
 
+// All supported system chains
 export const SystemChainList: Record<string, SystemChain> = {
   'people-polkadot': {
     name: 'people-polkadot',

--- a/packages/consts/src/util.ts
+++ b/packages/consts/src/util.ts
@@ -1,8 +1,12 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { NetworkId, SystemChainId } from 'types'
-import { NetworkList, SystemChainList } from './networks'
+import type { NetworkId, Networks, SystemChainId } from 'types'
+import {
+  NetworkList,
+  ProductionDisabledNetworks,
+  SystemChainList,
+} from './networks'
 import { SupportedProxies } from './proxies'
 
 // Check if proxy type is supported in the dashboard
@@ -70,3 +74,21 @@ export const getHubChainId = (network: NetworkId) => {
   }
   return 'statemint'
 }
+
+// Gets enabled networks depending on environment
+export const getEnabledNetworks = (): Networks =>
+  Object.entries(NetworkList).reduce((acc: Networks, [key, item]) => {
+    if (
+      !(
+        import.meta.env.PROD &&
+        ProductionDisabledNetworks.includes(key as NetworkId)
+      )
+    ) {
+      acc[key] = item
+    }
+    return acc
+  }, {})
+
+// Checks if a network is enabled
+export const isNetworkEnabled = (network: NetworkId) =>
+  Object.keys(getEnabledNetworks()).includes(network)

--- a/packages/consts/tsconfig.json
+++ b/packages/consts/tsconfig.json
@@ -13,7 +13,8 @@
     "esModuleInterop": false,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["vite/client"]
   },
   "include": ["src"]
 }

--- a/packages/global-bus/src/networkConfig/util.ts
+++ b/packages/global-bus/src/networkConfig/util.ts
@@ -4,7 +4,7 @@
 import { extractUrlValue, localStorageOrDefault } from '@w3ux/utils'
 import { NetworkKey, ProviderTypeKey, rpcEndpointKey } from 'consts'
 import { DefaultNetwork, NetworkList, SystemChainList } from 'consts/networks'
-import { getDefaultRpcEndpoints } from 'consts/util'
+import { getDefaultRpcEndpoints, getEnabledNetworks } from 'consts/util'
 import type {
   NetworkConfig,
   NetworkId,
@@ -16,7 +16,7 @@ import { setLocalRpcEndpoints } from './local'
 export const getInitialNetwork = () => {
   // Attempt to get network from URL
   const urlNetwork = extractUrlValue('n')
-  const urlNetworkValid = !!Object.values(NetworkList).find(
+  const urlNetworkValid = !!Object.values(getEnabledNetworks()).find(
     (n) => n.name === urlNetwork
   )
 
@@ -28,7 +28,7 @@ export const getInitialNetwork = () => {
 
   // Fallback 1: Use network from local storage if valid
   const localNetwork: NetworkId = localStorage.getItem(NetworkKey) as NetworkId
-  const localNetworkValid = !!Object.values(NetworkList).find(
+  const localNetworkValid = !!Object.values(getEnabledNetworks()).find(
     (n) => n.name === localNetwork
   )
   if (localNetworkValid) {

--- a/packages/locales/package.json
+++ b/packages/locales/package.json
@@ -19,5 +19,8 @@
     "i18next": "^25.0.2",
     "react-i18next": "^15.5.1",
     "utils": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "^6.3.5"
   }
 }

--- a/packages/locales/tsconfig.json
+++ b/packages/locales/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["vite/client"]
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       types:
         specifier: workspace:*
         version: link:../types
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@22.14.1)(sass@1.77.6)
 
   packages/dedot-api:
     dependencies:
@@ -403,6 +406,10 @@ importers:
       utils:
         specifier: workspace:*
         version: link:../utils
+    devDependencies:
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@22.14.1)(sass@1.77.6)
 
   packages/plugin-staking-api:
     dependencies:


### PR DESCRIPTION
Adds the ability to disable networks in a production environment.  Disabled Westend in preparation for the AssetHub migration.