### PR TITLE
fix: allow pools with no nominators to be tracked and displayed

### DIFF
--- a/packages/dedot-api/src/subscribe/activePool.ts
+++ b/packages/dedot-api/src/subscribe/activePool.ts
@@ -55,7 +55,8 @@ export class ActivePoolQuery<T extends StakingChain> {
         },
       ],
       async ([bondedPool, rewardPool, rewardAccount, nominators]) => {
-        if (bondedPool && rewardPool && nominators) {
+        if (bondedPool && rewardPool) {
+          const nominatorsData = nominators || { targets: [], submittedIn: 0 }
           const roleAddresses = Object.values(bondedPool.roles).map((role) =>
             role.address(this.api.consts.system.ss58Prefix)
           )
@@ -100,10 +101,10 @@ export class ActivePoolQuery<T extends StakingChain> {
             },
             rewardAccountBalance: rewardAccount.data.free,
             nominators: {
-              targets: nominators.targets.map((target) =>
+              targets: nominatorsData.targets.map((target) =>
                 target.address(this.api.consts.system.ss58Prefix)
               ),
-              submittedIn: nominators.submittedIn,
+              submittedIn: nominatorsData.submittedIn,
             },
           }
           addActivePool(activePool)


### PR DESCRIPTION
- Pools are now added to activePools even if the nominators value is undefined, ensuring all pool memberships are correctly shown in the UI.