### PR TITLE
fix: correct validator stake calculation on list and details views

### DIFF
--- a/packages/app/src/contexts/Validators/ValidatorEntries/index.tsx
+++ b/packages/app/src/contexts/Validators/ValidatorEntries/index.tsx
@@ -262,15 +262,10 @@ export const ValidatorsProvider = ({ children }: { children: ReactNode }) => {
     if (!inEra) {
       return 0n
     }
-    let totalStake = 0n
-    const { others, own } = inEra
-    if (own) {
-      totalStake = totalStake + BigInt(own)
-    }
-    others.forEach(({ value }) => {
-      totalStake = totalStake + BigInt(value)
-    })
-    return totalStake
+
+    // Use the total directly from the validator data, which comes from the chain
+    // This ensures we get the correct total even if we're missing some nominator data
+    return BigInt(inEra.total)
   }
 
   // Gets average validator reward for provided number of days

--- a/packages/app/src/overlay/canvas/ValidatorMetrics/index.tsx
+++ b/packages/app/src/overlay/canvas/ValidatorMetrics/index.tsx
@@ -62,12 +62,18 @@ export const ValidatorMetrics = () => {
   let validatorOwnStake = new BigNumber(0)
   let otherStake = new BigNumber(0)
   if (validatorInEra) {
-    const { others, own } = validatorInEra
-    others.forEach(({ value }) => {
-      otherStake = otherStake.plus(value)
-    })
+    const { own, total } = validatorInEra
+
+    // Set validator own stake
     if (own) {
       validatorOwnStake = new BigNumber(own)
+    }
+
+    // Calculate nominator stake as total minus own stake
+    // This ensures we get the correct total even if we're missing some nominator data
+    if (total) {
+      const totalStake = new BigNumber(total)
+      otherStake = totalStake.minus(validatorOwnStake)
     }
   }
 


### PR DESCRIPTION
The validator list was showing incorrect stake amounts for some validators (like RockX_Polkadot) because it was calculating the total by summing the others array which only contained the first page of nominators. This created a discrepancy where the main list showed much lower values (e.g. ~100k DOT) compared to the correct amounts (~1.4M DOT).

Closes #2724