### PR TITLE
fix: validator stake

### DIFF
--- a/packages/app/src/contexts/Validators/ValidatorEntries/index.tsx
+++ b/packages/app/src/contexts/Validators/ValidatorEntries/index.tsx
@@ -266,8 +266,8 @@ export const ValidatorsProvider = ({ children }: { children: ReactNode }) => {
     const { own, total } = inEra
     if (own) {
       totalStake = BigInt(own)
-      totalStake += BigInt(total)
     }
+    totalStake += BigInt(total)
     return totalStake
   }
 

--- a/packages/app/src/contexts/Validators/ValidatorEntries/index.tsx
+++ b/packages/app/src/contexts/Validators/ValidatorEntries/index.tsx
@@ -263,13 +263,11 @@ export const ValidatorsProvider = ({ children }: { children: ReactNode }) => {
       return 0n
     }
     let totalStake = 0n
-    const { others, own } = inEra
+    const { own, total } = inEra
     if (own) {
-      totalStake = totalStake + BigInt(own)
+      totalStake = BigInt(own)
+      totalStake += BigInt(total)
     }
-    others.forEach(({ value }) => {
-      totalStake = totalStake + BigInt(value)
-    })
     return totalStake
   }
 

--- a/packages/app/src/overlay/canvas/ValidatorMetrics/index.tsx
+++ b/packages/app/src/overlay/canvas/ValidatorMetrics/index.tsx
@@ -60,12 +60,11 @@ export const ValidatorMetrics = () => {
   const validatorInEra = stakers.find((s) => s.address === validator) || null
 
   let validatorOwnStake = new BigNumber(0)
-  let otherStake = new BigNumber(0)
+  let nominatorStake = new BigNumber(0)
   if (validatorInEra) {
-    const { others, own } = validatorInEra
-    others.forEach(({ value }) => {
-      otherStake = otherStake.plus(value)
-    })
+    const { own, total } = validatorInEra
+    nominatorStake = new BigNumber(total).minus(own)
+
     if (own) {
       validatorOwnStake = new BigNumber(own)
     }
@@ -131,7 +130,9 @@ export const ValidatorMetrics = () => {
             <Stat withIcon>
               <Token />
               {t('nominatorStake', { ns: 'modals' })}:{' '}
-              {planckToUnitBn(otherStake, units).decimalPlaces(0).toFormat()}{' '}
+              {planckToUnitBn(nominatorStake, units)
+                .decimalPlaces(0)
+                .toFormat()}{' '}
               {unit}
             </Stat>
           </h4>


### PR DESCRIPTION
Fixes an issue where `other` stakes were not summing to the correct total. Now uses `total - own` instead of looping others.