### PR TITLE
feat: Init advanced mode

### DIFF
--- a/packages/app/src/Router.tsx
+++ b/packages/app/src/Router.tsx
@@ -29,16 +29,18 @@ import {
   Route,
   Routes,
   useLocation,
+  useNavigate,
 } from 'react-router-dom'
 import { StakingApi } from 'StakingApi'
 import { Page } from 'ui-core/base'
 
 const RouterInner = () => {
+  const navigate = useNavigate()
   const { network } = useNetwork()
   const { pathname } = useLocation()
-  const { setContainerRefs } = useUi()
   const { pluginEnabled } = usePlugins()
   const { activeAddress } = useActiveAccounts()
+  const { setContainerRefs, advancedMode } = useUi()
 
   // References to outer container
   const mainInterfaceRef = useRef<HTMLDivElement>(null)
@@ -57,6 +59,11 @@ const RouterInner = () => {
 
   // Support active account from url
   useAccountFromUrl()
+
+  // Jump back to overview page on advanced mode change
+  useEffect(() => {
+    navigate(`/overview`)
+  }, [advancedMode])
 
   return (
     <ErrorBoundary FallbackComponent={ErrorFallbackApp}>

--- a/packages/app/src/common-types.ts
+++ b/packages/app/src/common-types.ts
@@ -24,6 +24,7 @@ declare global {
 export interface PageCategory {
   id: number
   key: string
+  advanced: boolean
 }
 
 export type PageCategoryItems = PageCategory[]
@@ -35,6 +36,7 @@ export interface PageItem {
   hash: string
   Entry: FC<PageProps>
   lottie: unknown
+  advanced: boolean
   bullet?: BulletType
 }
 

--- a/packages/app/src/config/pages.ts
+++ b/packages/app/src/config/pages.ts
@@ -13,14 +13,17 @@ export const PageCategories: PageCategoryItems = [
   {
     id: 1,
     key: 'default',
+    advanced: false,
   },
   {
     id: 2,
     key: 'stake',
+    advanced: false,
   },
   {
     id: 3,
     key: 'validators',
+    advanced: true,
   },
 ]
 
@@ -32,6 +35,7 @@ export const PagesConfig: PagesConfigItems = [
     hash: '/overview',
     Entry: Overview,
     lottie: 'globe',
+    advanced: false,
   },
   {
     category: 2,
@@ -40,6 +44,7 @@ export const PagesConfig: PagesConfigItems = [
     hash: '/pools',
     Entry: Pools,
     lottie: 'groups',
+    advanced: false,
   },
   {
     category: 2,
@@ -48,6 +53,7 @@ export const PagesConfig: PagesConfigItems = [
     hash: '/nominate',
     Entry: Nominate,
     lottie: 'trending',
+    advanced: false,
   },
   {
     category: 2,
@@ -56,6 +62,7 @@ export const PagesConfig: PagesConfigItems = [
     hash: '/rewards',
     Entry: Rewards,
     lottie: 'analytics',
+    advanced: false,
   },
   {
     category: 3,
@@ -64,6 +71,7 @@ export const PagesConfig: PagesConfigItems = [
     hash: '/validators',
     Entry: Validators,
     lottie: 'view',
+    advanced: false,
   },
   {
     category: 3,
@@ -72,5 +80,6 @@ export const PagesConfig: PagesConfigItems = [
     hash: '/operators',
     Entry: Operators,
     lottie: 'label',
+    advanced: false,
   },
 ]

--- a/packages/app/src/contexts/UI/defaults.ts
+++ b/packages/app/src/contexts/UI/defaults.ts
@@ -13,4 +13,6 @@ export const defaultUIContext: UIContextInterface = {
   sideMenuMinimised: false,
   containerRefs: {},
   isBraveBrowser: false,
+  advancedMode: false,
+  setAdvancedMode: (value) => {},
 }

--- a/packages/app/src/contexts/UI/index.tsx
+++ b/packages/app/src/contexts/UI/index.tsx
@@ -18,6 +18,16 @@ export const UIProvider = ({ children }: { children: ReactNode }) => {
   // Store whether in Brave browser. Used for light client warning
   const [isBraveBrowser, setIsBraveBrowser] = useState<boolean>(false)
 
+  // Get advanced mode state from local storage, default to false
+  const [advancedMode, setAdvancedModeState] = useState<boolean>(
+    localStorageOrDefault('advanced_mode', false, true) as boolean
+  )
+
+  const setAdvancedMode = (value: boolean) => {
+    localStorage.setItem('advancedMode', String(value))
+    setAdvancedModeState(value)
+  }
+
   // Store references for main app containers
   const [containerRefs, setContainerRefsState] = useState<
     Record<string, RefObject<HTMLDivElement | null>>
@@ -85,6 +95,8 @@ export const UIProvider = ({ children }: { children: ReactNode }) => {
         containerRefs,
         isBraveBrowser,
         userSideMenuMinimised,
+        advancedMode,
+        setAdvancedMode,
       }}
     >
       {children}

--- a/packages/app/src/contexts/UI/types.ts
+++ b/packages/app/src/contexts/UI/types.ts
@@ -14,4 +14,6 @@ export interface UIContextInterface {
   sideMenuMinimised: boolean
   containerRefs: Record<string, RefObject<HTMLDivElement | null>>
   isBraveBrowser: boolean
+  advancedMode: boolean
+  setAdvancedMode: (value: boolean) => void
 }

--- a/packages/app/src/library/SideMenu/Advanced.tsx
+++ b/packages/app/src/library/SideMenu/Advanced.tsx
@@ -1,0 +1,43 @@
+// Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import {
+  faSlidersH,
+  faToggleOff,
+  faToggleOn,
+} from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useUi } from 'contexts/UI'
+import type { UIContextInterface } from 'contexts/UI/types'
+import { useTranslation } from 'react-i18next'
+import { AdvancedToggleWrapper } from './Wrapper'
+
+export const AdvancedToggle = ({ minimised }: { minimised: boolean }) => {
+  const { t } = useTranslation('app')
+  const { advancedMode, setAdvancedMode }: UIContextInterface = useUi()
+
+  return (
+    <AdvancedToggleWrapper
+      onClick={() => setAdvancedMode(!advancedMode)}
+      role="switch"
+      aria-checked={advancedMode}
+      aria-label={t('advanced')}
+    >
+      <span style={{ color: 'var(--text-color-primary)' }}>
+        <FontAwesomeIcon icon={faSlidersH} />
+      </span>
+      {!minimised && <h4>{t('advanced')}</h4>}
+
+      <FontAwesomeIcon
+        className="toggle"
+        icon={advancedMode ? faToggleOn : faToggleOff}
+        style={{
+          marginLeft: minimised ? '0.75rem' : 0,
+          color: advancedMode
+            ? 'var(--accent-color-primary)'
+            : 'var(--text-color-tertiary)',
+        }}
+      />
+    </AdvancedToggleWrapper>
+  )
+}

--- a/packages/app/src/library/SideMenu/Main.tsx
+++ b/packages/app/src/library/SideMenu/Main.tsx
@@ -8,7 +8,6 @@ import { useBalances } from 'contexts/Balances'
 import { useActivePool } from 'contexts/Pools/ActivePool'
 import { useStaking } from 'contexts/Staking'
 import { useUi } from 'contexts/UI'
-import type { UIContextInterface } from 'contexts/UI/types'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useSyncing } from 'hooks/useSyncing'
 import { Fragment } from 'react'
@@ -25,7 +24,7 @@ export const Main = () => {
   const { formatWithPrefs } = useValidators()
   const { activeAddress } = useActiveAccounts()
   const { inSetup: inNominatorSetup } = useStaking()
-  const { sideMenuMinimised }: UIContextInterface = useUi()
+  const { sideMenuMinimised, advancedMode } = useUi()
   const { getNominations, getStakingLedger } = useBalances()
   const { controllerUnmigrated } = getStakingLedger(activeAddress)
 
@@ -75,12 +74,20 @@ export const Main = () => {
     }
     i++
   }
+
+  const categories = advancedMode
+    ? PageCategories
+    : PageCategories.filter(({ advanced }) => !advanced)
+
   const pageConfig = {
-    categories: PageCategories,
+    categories,
     pages,
   }
 
-  const pagesToDisplay: PagesConfigItems = Object.values(pageConfig.pages)
+  let pagesToDisplay: PagesConfigItems = Object.values(pageConfig.pages)
+  if (!advancedMode) {
+    pagesToDisplay = pagesToDisplay.filter(({ advanced }) => !advanced)
+  }
 
   return (
     <>

--- a/packages/app/src/library/SideMenu/Wrapper.ts
+++ b/packages/app/src/library/SideMenu/Wrapper.ts
@@ -164,3 +164,21 @@ export const BulletWrapper = styled.div`
     }
   }
 `
+export const AdvancedToggleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  cursor: pointer;
+  user-select: none;
+  transition: all 0.15s;
+  margin-bottom: 1rem;
+  width: 100%;
+
+  > h4 {
+    padding: 0 0.75rem;
+  }
+
+  > .toggle {
+    font-size: 1.75rem;
+  }
+`

--- a/packages/app/src/library/SideMenu/index.tsx
+++ b/packages/app/src/library/SideMenu/index.tsx
@@ -24,6 +24,7 @@ import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Page } from 'ui-core/base'
 import { useOverlay } from 'ui-overlay'
+import { AdvancedToggle } from './Advanced'
 import { Heading } from './Heading/Heading'
 import { Main } from './Main'
 import { Secondary } from './Secondary'
@@ -145,6 +146,11 @@ export const SideMenu = () => {
                 size: sideMenuMinimised ? '1.05em' : '0.9em',
               }}
             />
+          </div>
+        </section>
+        <section>
+          <div className="inner">
+            <AdvancedToggle minimised={sideMenuMinimised} />
           </div>
         </section>
       </Wrapper>

--- a/packages/locales/src/resources/en/app.json
+++ b/packages/locales/src/resources/en/app.json
@@ -16,6 +16,7 @@
     "address": "Address",
     "addressCopiedToClipboard": "Address Copied to Clipboard",
     "addresses": "Addresses",
+    "advanced": "Advanced",
     "all": "All",
     "allowAll": "Allow All",
     "allowAnyoneCompound": "Allow anyone to compound your rewards.",

--- a/packages/locales/src/resources/es/app.json
+++ b/packages/locales/src/resources/es/app.json
@@ -16,6 +16,7 @@
     "address": "Dirección",
     "addressCopiedToClipboard": "Dirección Copiada",
     "addresses": "Direcciones",
+    "advanced": "Avanzado",
     "all": "Todos",
     "allowAll": "Permitir Todo",
     "allowAnyoneCompound": "Permitir que cualquiera reinvierta tus recompensas",

--- a/packages/locales/src/resources/zh/app.json
+++ b/packages/locales/src/resources/zh/app.json
@@ -16,6 +16,7 @@
     "address": "地址",
     "addressCopiedToClipboard": "复制到剪贴板的地址",
     "addresses": "地址",
+    "advanced": "高级模式",
     "all": "全部",
     "allowAll": "允许所有",
     "allowAnyoneCompound": "允许任何人代表您复利收益",


### PR DESCRIPTION
Introduces advanced mode toggle.

- [x] Add toggle at the bottom of side menu
- [x] Hide validators and operators pages in simple mode
- [x] Jump back to overview page on advanced toggle 
- [ ] In simple mode, combine Pools and Nominate pages into one Stake page