### PR TITLE
feat: Migrate Westend api to asset hub

### DIFF
--- a/packages/app/src/Providers.tsx
+++ b/packages/app/src/Providers.tsx
@@ -7,7 +7,7 @@ import {
   HardwareAccountsProvider,
 } from '@w3ux/react-connect-kit'
 import { DappName } from 'consts'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { ActiveAccountsProvider } from 'contexts/ActiveAccounts'
 import { APIProvider } from 'contexts/Api'
 import { BalancesProvider } from 'contexts/Balances'
@@ -48,7 +48,7 @@ import { OverlayProvider } from 'ui-overlay'
 
 export const Providers = () => {
   const { network } = useNetwork()
-  const { ss58 } = getNetworkData(network)
+  const { ss58 } = getStakingChainData(network)
 
   return withProviders(
     // !! Provider order matters.

--- a/packages/app/src/contexts/Balances/index.tsx
+++ b/packages/app/src/contexts/Balances/index.tsx
@@ -23,8 +23,8 @@ export const [BalancesContext, useBalances] =
 export const BalancesProvider = ({ children }: { children: ReactNode }) => {
   const { network } = useNetwork()
   const { getChainSpec } = useApi()
-  const balanceChain = getStakingChain(network)
-  const { existentialDeposit } = getChainSpec(balanceChain)
+  const stakingChain = getStakingChain(network)
+  const { existentialDeposit } = getChainSpec(stakingChain)
 
   // Store account balances state
   type StateBalances = Record<string, Record<string, AccountBalance>>
@@ -39,7 +39,7 @@ export const BalancesProvider = ({ children }: { children: ReactNode }) => {
     if (!address) {
       return defaultAccountBalance
     }
-    return accountBalances?.[balanceChain]?.[address] || defaultAccountBalance
+    return accountBalances?.[stakingChain]?.[address] || defaultAccountBalance
   }
 
   // Get an account's ed reserved balance

--- a/packages/app/src/contexts/Balances/index.tsx
+++ b/packages/app/src/contexts/Balances/index.tsx
@@ -3,7 +3,7 @@
 
 import { createSafeContext } from '@w3ux/hooks'
 import { maxBigInt } from '@w3ux/utils'
-import { getDefaultBalancesChain } from 'consts/util'
+import { getStakingChain } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import {
@@ -23,7 +23,7 @@ export const [BalancesContext, useBalances] =
 export const BalancesProvider = ({ children }: { children: ReactNode }) => {
   const { network } = useNetwork()
   const { getChainSpec } = useApi()
-  const balanceChain = getDefaultBalancesChain(network)
+  const balanceChain = getStakingChain(network)
   const { existentialDeposit } = getChainSpec(balanceChain)
 
   // Store account balances state

--- a/packages/app/src/contexts/Balances/index.tsx
+++ b/packages/app/src/contexts/Balances/index.tsx
@@ -3,6 +3,7 @@
 
 import { createSafeContext } from '@w3ux/hooks'
 import { maxBigInt } from '@w3ux/utils'
+import { getDefaultBalancesChain } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import {
@@ -22,7 +23,8 @@ export const [BalancesContext, useBalances] =
 export const BalancesProvider = ({ children }: { children: ReactNode }) => {
   const { network } = useNetwork()
   const { getChainSpec } = useApi()
-  const { existentialDeposit } = getChainSpec(network)
+  const balanceChain = getDefaultBalancesChain(network)
+  const { existentialDeposit } = getChainSpec(balanceChain)
 
   // Store account balances state
   type StateBalances = Record<string, Record<string, AccountBalance>>
@@ -37,7 +39,7 @@ export const BalancesProvider = ({ children }: { children: ReactNode }) => {
     if (!address) {
       return defaultAccountBalance
     }
-    return accountBalances?.[network]?.[address] || defaultAccountBalance
+    return accountBalances?.[balanceChain]?.[address] || defaultAccountBalance
   }
 
   // Get an account's ed reserved balance

--- a/packages/app/src/contexts/Connect/ExternalAccounts/index.tsx
+++ b/packages/app/src/contexts/Connect/ExternalAccounts/index.tsx
@@ -3,7 +3,7 @@
 
 import { createSafeContext } from '@w3ux/hooks'
 import { ellipsisFn, formatAccountSs58 } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useNetwork } from 'contexts/Network'
 import {
@@ -29,7 +29,7 @@ export const ExternalAccountsProvider = ({
 }) => {
   const { network } = useNetwork()
   const { activeAddress, setActiveAccount } = useActiveAccounts()
-  const { ss58 } = getNetworkData(network)
+  const { ss58 } = getStakingChainData(network)
 
   // Adds an external account to imported accounts
   const addExternalAccount = (

--- a/packages/app/src/contexts/Connect/ImportedAccounts/index.tsx
+++ b/packages/app/src/contexts/Connect/ImportedAccounts/index.tsx
@@ -4,7 +4,7 @@
 import { createSafeContext, useEffectIgnoreInitial } from '@w3ux/hooks'
 import { useExtensionAccounts } from '@w3ux/react-connect-kit'
 import { ManualSigners } from 'consts'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useNetwork } from 'contexts/Network'
 import type { ReactNode } from 'react'
@@ -27,7 +27,7 @@ export const ImportedAccountsProvider = ({
   const { getExtensionAccounts } = useExtensionAccounts()
   const { setActiveAccount, setActiveProxy } = useActiveAccounts()
 
-  const { ss58 } = getNetworkData(network)
+  const { ss58 } = getStakingChainData(network)
   // Get the imported extension accounts formatted with the current network's ss58 prefix
   const extensionAccounts = getExtensionAccounts(ss58)
   const allAccounts = extensionAccounts.concat(otherAccounts)

--- a/packages/app/src/contexts/Connect/OtherAccounts/index.tsx
+++ b/packages/app/src/contexts/Connect/OtherAccounts/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@w3ux/react-connect-kit'
 import type { HardwareAccountSource } from '@w3ux/types'
 import { setStateWithRef } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useNetwork } from 'contexts/Network'
 import { getInitialExternalAccounts } from 'global-bus/util'
@@ -34,7 +34,7 @@ export const OtherAccountsProvider = ({
   const { activeAddress, setActiveAccount } = useActiveAccounts()
   const { extensionsSynced, getExtensionAccounts } = useExtensionAccounts()
 
-  const { ss58 } = getNetworkData(network)
+  const { ss58 } = getStakingChainData(network)
   const extensionAccounts = getExtensionAccounts(ss58)
 
   // Store whether other (non-extension) accounts have been initialised

--- a/packages/app/src/contexts/LedgerHardware/index.tsx
+++ b/packages/app/src/contexts/LedgerHardware/index.tsx
@@ -5,6 +5,7 @@ import { createSafeContext } from '@w3ux/hooks'
 import type { MaybeString } from '@w3ux/types'
 import { setStateWithRef } from '@w3ux/utils'
 import { compare } from 'compare-versions'
+import { getDefaultTxChain } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import type { ReactNode } from 'react'
@@ -32,7 +33,9 @@ export const LedgerHardwareProvider = ({
   const { t } = useTranslation('modals')
   const { network } = useNetwork()
   const { getChainSpec } = useApi()
-  const { transactionVersion } = getChainSpec(network).version
+  const { transactionVersion } = getChainSpec(
+    getDefaultTxChain(network)
+  ).version
 
   // Store whether a Ledger device task is in progress
   const [isExecuting, setIsExecutingState] = useState<boolean>(false)

--- a/packages/app/src/contexts/LedgerHardware/index.tsx
+++ b/packages/app/src/contexts/LedgerHardware/index.tsx
@@ -5,7 +5,7 @@ import { createSafeContext } from '@w3ux/hooks'
 import type { MaybeString } from '@w3ux/types'
 import { setStateWithRef } from '@w3ux/utils'
 import { compare } from 'compare-versions'
-import { getDefaultTxChain } from 'consts/util'
+import { getStakingChain } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import type { ReactNode } from 'react'
@@ -33,9 +33,7 @@ export const LedgerHardwareProvider = ({
   const { t } = useTranslation('modals')
   const { network } = useNetwork()
   const { getChainSpec } = useApi()
-  const { transactionVersion } = getChainSpec(
-    getDefaultTxChain(network)
-  ).version
+  const { transactionVersion } = getChainSpec(getStakingChain(network)).version
 
   // Store whether a Ledger device task is in progress
   const [isExecuting, setIsExecutingState] = useState<boolean>(false)

--- a/packages/app/src/contexts/NominatorSetups/index.tsx
+++ b/packages/app/src/contexts/NominatorSetups/index.tsx
@@ -4,7 +4,7 @@
 import { createSafeContext, useEffectIgnoreInitial } from '@w3ux/hooks'
 import { unitToPlanck } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useNetwork } from 'contexts/Network'
@@ -36,7 +36,7 @@ export const NominatorSetupsProvider = ({
   const { activeAddress } = useActiveAccounts()
   const { getTransferOptions } = useTransferOptions()
   const { accounts, stringifiedAccountsKey } = useImportedAccounts()
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
 
   // Store all imported accounts nominator setups
   const [nominatorSetups, setNominatorSetupsState] = useState<NominatorSetups>(

--- a/packages/app/src/contexts/PoolSetups/index.tsx
+++ b/packages/app/src/contexts/PoolSetups/index.tsx
@@ -4,7 +4,7 @@
 import { createSafeContext, useEffectIgnoreInitial } from '@w3ux/hooks'
 import { unitToPlanck } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useNetwork } from 'contexts/Network'
@@ -26,7 +26,7 @@ export const PoolSetupsProvider = ({ children }: { children: ReactNode }) => {
   const { network } = useNetwork()
   const { activeAddress } = useActiveAccounts()
   const { accounts, stringifiedAccountsKey } = useImportedAccounts()
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
 
   // Store all imported accounts pool creation setups
   const [poolSetups, setPoolSetupsState] = useState<PoolSetups>({})

--- a/packages/app/src/contexts/Staking/index.tsx
+++ b/packages/app/src/contexts/Staking/index.tsx
@@ -3,7 +3,7 @@
 
 import { createSafeContext, useEffectIgnoreInitial } from '@w3ux/hooks'
 import { setStateWithRef } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useBalances } from 'contexts/Balances'
 import { useNetwork } from 'contexts/Network'
@@ -32,7 +32,7 @@ export const StakingProvider = ({ children }: { children: ReactNode }) => {
   const { activeAddress } = useActiveAccounts()
   const { getStakingLedger, getNominations } = useBalances()
   const { isReady, activeEra, getApiStatus, serviceApi } = useApi()
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
 
   // Store eras stakers in state
   const [eraStakers, setEraStakers] = useState<EraStakers>(defaultEraStakers)

--- a/packages/app/src/contexts/TokenPrice/index.tsx
+++ b/packages/app/src/contexts/TokenPrice/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { createSafeContext } from '@w3ux/hooks'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useCurrency } from 'contexts/Currency'
 import { useNetwork } from 'contexts/Network'
 import { usePlugins } from 'contexts/Plugins'
@@ -24,7 +24,7 @@ export const TokenPricesProvider = ({ children }: { children: ReactNode }) => {
   const { network } = useNetwork()
   const { currency } = useCurrency()
   const { pluginEnabled } = usePlugins()
-  const { unit } = getNetworkData(network)
+  const { unit } = getStakingChainData(network)
 
   // Store token price and change
   const [tokenPrice, setTokenPrice] =

--- a/packages/app/src/contexts/TransferOptions/index.tsx
+++ b/packages/app/src/contexts/TransferOptions/index.tsx
@@ -4,7 +4,7 @@
 import { createSafeContext, useEffectIgnoreInitial } from '@w3ux/hooks'
 import { maxBigInt, planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useBalances } from 'contexts/Balances'
@@ -30,7 +30,7 @@ export const TransferOptionsProvider = ({
   const { getStakingLedger, getAccountBalance, getEdReserved } = useBalances()
 
   const { poolMembership } = getStakingLedger(activeAddress)
-  const { units, defaultFeeReserve } = getNetworkData(network)
+  const { units, defaultFeeReserve } = getStakingChainData(network)
 
   // A user-configurable reserve amount to be used to pay for transaction fees
   const [feeReserve, setFeeReserve] = useState<bigint>(

--- a/packages/app/src/contexts/Validators/FavoriteValidators/index.tsx
+++ b/packages/app/src/contexts/Validators/FavoriteValidators/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { createSafeContext, useEffectIgnoreInitial } from '@w3ux/hooks'
-import { getNetworkData } from 'consts/util'
+import { getRelayChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import type { ReactNode } from 'react'
@@ -23,7 +23,7 @@ export const FavoriteValidatorsProvider = ({
   const { isReady } = useApi()
   const { network } = useNetwork()
   const { fetchValidatorPrefs } = useValidators()
-  const { name } = getNetworkData(network)
+  const { name } = getRelayChainData(network)
 
   // Stores the user's favorite validators
   const [favorites, setFavorites] = useState<string[]>(getLocalFavorites(name))

--- a/packages/app/src/contexts/WalletConnect/index.tsx
+++ b/packages/app/src/contexts/WalletConnect/index.tsx
@@ -5,6 +5,7 @@ import { createSafeContext } from '@w3ux/hooks'
 import { WalletConnectModal } from '@walletconnect/modal'
 import UniversalProvider from '@walletconnect/universal-provider'
 import { getSdkError } from '@walletconnect/utils'
+import { getDefaultTxChain } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { getUnixTime } from 'date-fns'
@@ -27,7 +28,7 @@ export const WalletConnectProvider = ({
 }) => {
   const { network } = useNetwork()
   const { isReady, getChainSpec } = useApi()
-  const { genesisHash } = getChainSpec(network)
+  const { genesisHash } = getChainSpec(getDefaultTxChain(network))
 
   // The WalletConnect provider
   const wcProvider = useRef<UniversalProvider | null>(null)

--- a/packages/app/src/contexts/WalletConnect/index.tsx
+++ b/packages/app/src/contexts/WalletConnect/index.tsx
@@ -5,7 +5,7 @@ import { createSafeContext } from '@w3ux/hooks'
 import { WalletConnectModal } from '@walletconnect/modal'
 import UniversalProvider from '@walletconnect/universal-provider'
 import { getSdkError } from '@walletconnect/utils'
-import { getDefaultTxChain } from 'consts/util'
+import { getStakingChain } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { getUnixTime } from 'date-fns'
@@ -28,7 +28,7 @@ export const WalletConnectProvider = ({
 }) => {
   const { network } = useNetwork()
   const { isReady, getChainSpec } = useApi()
-  const { genesisHash } = getChainSpec(getDefaultTxChain(network))
+  const { genesisHash } = getChainSpec(getStakingChain(network))
 
   // The WalletConnect provider
   const wcProvider = useRef<UniversalProvider | null>(null)

--- a/packages/app/src/hooks/useAverageRewardRate/index.tsx
+++ b/packages/app/src/hooks/useAverageRewardRate/index.tsx
@@ -3,7 +3,7 @@
 
 import { planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
@@ -19,7 +19,7 @@ export const useAverageRewardRate = (): UseAverageRewardRate => {
   } = useApi()
   const { network } = useNetwork()
   const { avgCommission, averageEraValidatorReward } = useValidators()
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
 
   // Get average reward rates.
   const getAverageRewardRate = (compounded: boolean): AverageRewardRate => {

--- a/packages/app/src/hooks/useAverageRewardRate/index.tsx
+++ b/packages/app/src/hooks/useAverageRewardRate/index.tsx
@@ -15,7 +15,7 @@ export const useAverageRewardRate = (): UseAverageRewardRate => {
   const { erasPerDay } = useErasPerDay()
   const { lastTotalStake } = useApi().stakingMetrics
   const {
-    relayMetrics: { totalIssuance },
+    stakingMetrics: { totalIssuance },
   } = useApi()
   const { network } = useNetwork()
   const { avgCommission, averageEraValidatorReward } = useValidators()

--- a/packages/app/src/hooks/useCreatePoolAccounts/index.tsx
+++ b/packages/app/src/hooks/useCreatePoolAccounts/index.tsx
@@ -1,6 +1,7 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import { getDefaultBalancesChain } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { createPoolAccounts as createUtil } from 'utils'
@@ -9,7 +10,9 @@ export const useCreatePoolAccounts = () => {
   const { network } = useNetwork()
   const { getChainSpec, getConsts } = useApi()
   const { poolsPalletId } = getConsts(network)
-  const { ss58Format } = getChainSpec(network).properties
+  const { ss58Format } = getChainSpec(
+    getDefaultBalancesChain(network)
+  ).properties
 
   const createPoolAccounts = (poolId: number) =>
     createUtil(poolId, poolsPalletId, ss58Format)

--- a/packages/app/src/hooks/useCreatePoolAccounts/index.tsx
+++ b/packages/app/src/hooks/useCreatePoolAccounts/index.tsx
@@ -10,9 +10,7 @@ export const useCreatePoolAccounts = () => {
   const { network } = useNetwork()
   const { getChainSpec, getConsts } = useApi()
   const { poolsPalletId } = getConsts(network)
-  const { ss58Format } = getChainSpec(
-    getStakingChain(network)
-  ).properties
+  const { ss58Format } = getChainSpec(getStakingChain(network)).properties
 
   const createPoolAccounts = (poolId: number) =>
     createUtil(poolId, poolsPalletId, ss58Format)

--- a/packages/app/src/hooks/useCreatePoolAccounts/index.tsx
+++ b/packages/app/src/hooks/useCreatePoolAccounts/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { getDefaultBalancesChain } from 'consts/util'
+import { getStakingChain } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { createPoolAccounts as createUtil } from 'utils'
@@ -11,7 +11,7 @@ export const useCreatePoolAccounts = () => {
   const { getChainSpec, getConsts } = useApi()
   const { poolsPalletId } = getConsts(network)
   const { ss58Format } = getChainSpec(
-    getDefaultBalancesChain(network)
+    getStakingChain(network)
   ).properties
 
   const createPoolAccounts = (poolId: number) =>

--- a/packages/app/src/hooks/useFillVariables/index.tsx
+++ b/packages/app/src/hooks/useFillVariables/index.tsx
@@ -5,7 +5,7 @@ import { capitalizeFirstLetter, planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
 import { MaxNominations } from 'consts'
 import {
-  getDefaultBalancesChain,
+  getStakingChain,
   getRelayChainData,
   getStakingChainData,
 } from 'consts/util'
@@ -25,7 +25,7 @@ export const useFillVariables = () => {
   const { network } = useNetwork()
   const { maxSupportedDays } = useErasPerDay()
   const { maxExposurePageSize } = getConsts(network)
-  const { existentialDeposit } = getChainSpec(getDefaultBalancesChain(network))
+  const { existentialDeposit } = getChainSpec(getStakingChain(network))
   const { name } = getRelayChainData(network)
   const { unit, units } = getStakingChainData(network)
 

--- a/packages/app/src/hooks/useFillVariables/index.tsx
+++ b/packages/app/src/hooks/useFillVariables/index.tsx
@@ -4,7 +4,7 @@
 import { capitalizeFirstLetter, planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
 import { MaxNominations } from 'consts'
-import { getNetworkData } from 'consts/util'
+import { getDefaultBalancesChain, getNetworkData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import type { AnyJson } from 'types'
@@ -21,7 +21,7 @@ export const useFillVariables = () => {
   const { network } = useNetwork()
   const { maxSupportedDays } = useErasPerDay()
   const { maxExposurePageSize } = getConsts(network)
-  const { existentialDeposit } = getChainSpec(network)
+  const { existentialDeposit } = getChainSpec(getDefaultBalancesChain(network))
   const { unit, units, name } = getNetworkData(network)
 
   const fillVariables = (d: AnyJson, keys: string[]) => {

--- a/packages/app/src/hooks/useFillVariables/index.tsx
+++ b/packages/app/src/hooks/useFillVariables/index.tsx
@@ -4,7 +4,11 @@
 import { capitalizeFirstLetter, planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
 import { MaxNominations } from 'consts'
-import { getDefaultBalancesChain, getNetworkData } from 'consts/util'
+import {
+  getDefaultBalancesChain,
+  getRelayChainData,
+  getStakingChainData,
+} from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import type { AnyJson } from 'types'
@@ -22,7 +26,8 @@ export const useFillVariables = () => {
   const { maxSupportedDays } = useErasPerDay()
   const { maxExposurePageSize } = getConsts(network)
   const { existentialDeposit } = getChainSpec(getDefaultBalancesChain(network))
-  const { unit, units, name } = getNetworkData(network)
+  const { name } = getRelayChainData(network)
+  const { unit, units } = getStakingChainData(network)
 
   const fillVariables = (d: AnyJson, keys: string[]) => {
     const fields: AnyJson = Object.entries(d).filter(([k]) => keys.includes(k))

--- a/packages/app/src/hooks/useFillVariables/index.tsx
+++ b/packages/app/src/hooks/useFillVariables/index.tsx
@@ -5,8 +5,8 @@ import { capitalizeFirstLetter, planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
 import { MaxNominations } from 'consts'
 import {
-  getStakingChain,
   getRelayChainData,
+  getStakingChain,
   getStakingChainData,
 } from 'consts/util'
 import { useApi } from 'contexts/Api'

--- a/packages/app/src/hooks/useSubmitExtrinsic/index.tsx
+++ b/packages/app/src/hooks/useSubmitExtrinsic/index.tsx
@@ -4,7 +4,7 @@
 import { useExtensionAccounts, useExtensions } from '@w3ux/react-connect-kit'
 import type { HardwareAccount } from '@w3ux/types'
 import { DappName, ManualSigners } from 'consts'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useBalances } from 'contexts/Balances'
@@ -50,7 +50,7 @@ export const useSubmitExtrinsic = ({
   const { handleResetLedgerTask } = useLedgerHardware()
   const { getExtensionAccount } = useExtensionAccounts()
   const { getAccount, requiresManualSign } = useImportedAccounts()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   // Store the uid for this transaction.
   const [uid, setUid] = useState<number>(0)

--- a/packages/app/src/library/AccountInput/index.tsx
+++ b/packages/app/src/library/AccountInput/index.tsx
@@ -5,7 +5,7 @@ import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Polkicon } from '@w3ux/react-polkicon'
 import { formatAccountSs58, isValidAddress } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useNetwork } from 'contexts/Network'
 import type { FormEvent } from 'react'
@@ -33,7 +33,7 @@ export const AccountInput = ({
   const { network } = useNetwork()
   const { accounts } = useImportedAccounts()
   const { setModalResize } = useOverlay().modal
-  const { ss58 } = getNetworkData(network)
+  const { ss58 } = getStakingChainData(network)
 
   // store current input value
   const [value, setValue] = useState<string>(initialValue || '')

--- a/packages/app/src/library/Balance/WithFiat/index.tsx
+++ b/packages/app/src/library/Balance/WithFiat/index.tsx
@@ -4,7 +4,7 @@
 import { Odometer } from '@w3ux/react-odometer'
 import { minDecimalPlaces } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import type { ReactNode } from 'react'
 import { CardLabel, TokenFiat } from 'ui-core/base'
@@ -22,7 +22,7 @@ export const WithFiat = ({
   label?: string
 }) => {
   const { network } = useNetwork()
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
 
   const valueFormatted =
     String(value) === '0' ? 0 : new BigNumber(value).toFormat(units)

--- a/packages/app/src/library/BarChart/BondedChart.tsx
+++ b/packages/app/src/library/BarChart/BondedChart.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { BarSegment } from 'library/BarChart/BarSegment'
 import { LegendItem } from 'library/BarChart/LegendItem'
@@ -20,7 +20,7 @@ export const BondedChart = ({
   const { t } = useTranslation('app')
   const { network } = useNetwork()
   const totalUnlocking = unlocking.plus(unlocked)
-  const { unit } = getNetworkData(network)
+  const { unit } = getStakingChainData(network)
 
   const MinimumLowerBound = 0.5
   const MinimumNoNZeroPercent = 13

--- a/packages/app/src/library/EstimatedTxFee/index.tsx
+++ b/packages/app/src/library/EstimatedTxFee/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { useTxMeta } from 'contexts/TxMeta'
 import { useTranslation } from 'react-i18next'
@@ -12,9 +12,9 @@ import type { EstimatedTxFeeProps } from './types'
 
 export const EstimatedTxFee = ({ uid, format }: EstimatedTxFeeProps) => {
   const { t } = useTranslation('app')
-  const { getTxSubmission } = useTxMeta()
   const { network } = useNetwork()
-  const { unit, units } = getNetworkData(network)
+  const { getTxSubmission } = useTxMeta()
+  const { unit, units } = getStakingChainData(network)
 
   const txSubmission = getTxSubmission(uid)
   const fee = txSubmission?.fee || 0n

--- a/packages/app/src/library/Form/Bond/BondFeedback.tsx
+++ b/packages/app/src/library/Form/Bond/BondFeedback.tsx
@@ -3,7 +3,7 @@
 
 import { maxBigInt, planckToUnit, unitToPlanck } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
@@ -37,7 +37,7 @@ export const BondFeedback = ({
     poolsConfig: { minJoinBond, minCreateBond },
     stakingMetrics: { minNominatorBond },
   } = useApi()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const { getTransferOptions } = useTransferOptions()
   const allTransferOptions = getTransferOptions(activeAddress)
 

--- a/packages/app/src/library/Form/Bond/BondInput.tsx
+++ b/packages/app/src/library/Form/Bond/BondInput.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useNetwork } from 'contexts/Network'
 import type { ChangeEvent } from 'react'
@@ -24,7 +24,7 @@ export const BondInput = ({
   const { t } = useTranslation('app')
   const { network } = useNetwork()
   const { activeAddress } = useActiveAccounts()
-  const { unit } = getNetworkData(network)
+  const { unit } = getStakingChainData(network)
 
   // the current local bond value
   const [localBond, setLocalBond] = useState<string>(value)

--- a/packages/app/src/library/Form/CreatePoolStatusBar/index.tsx
+++ b/packages/app/src/library/Form/CreatePoolStatusBar/index.tsx
@@ -5,7 +5,7 @@ import { faFlag } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { useSyncing } from 'hooks/useSyncing'
@@ -18,7 +18,7 @@ export const CreatePoolStatusBar = ({ value }: NominateStatusBarProps) => {
   const { minCreateBond } = useApi().poolsConfig
   const { network } = useNetwork()
   const { syncing } = useSyncing(['initialization'])
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   const minCreateBondUnit = new BigNumber(planckToUnit(minCreateBond, units))
   const sectionClassName =

--- a/packages/app/src/library/Form/NominateStatusBar/index.tsx
+++ b/packages/app/src/library/Form/NominateStatusBar/index.tsx
@@ -5,7 +5,7 @@ import { faFlag } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useHelp } from 'contexts/Help'
 import { useNetwork } from 'contexts/Network'
@@ -23,7 +23,7 @@ export const NominateStatusBar = ({ value }: NominateStatusBarProps) => {
   } = useApi()
   const { network } = useNetwork()
   const { syncing } = useSyncing(['initialization'])
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   const minNominatorBondUnit = new BigNumber(
     planckToUnit(minNominatorBond, units)

--- a/packages/app/src/library/Form/Unbond/UnbondFeedback.tsx
+++ b/packages/app/src/library/Form/Unbond/UnbondFeedback.tsx
@@ -3,7 +3,7 @@
 
 import { maxBigInt, planckToUnit, unitToPlanck } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
@@ -37,7 +37,7 @@ export const UnbondFeedback = ({
     stakingMetrics: { minNominatorBond },
   } = useApi()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const allTransferOptions = getTransferOptions(activeAddress)
   const defaultValue = defaultBond ? String(defaultBond) : ''
 

--- a/packages/app/src/library/Form/Unbond/UnbondInput.tsx
+++ b/packages/app/src/library/Form/Unbond/UnbondInput.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useNetwork } from 'contexts/Network'
 import type { ChangeEvent } from 'react'
@@ -25,7 +25,7 @@ export const UnbondInput = ({
   const { network } = useNetwork()
   const { activeAddress } = useActiveAccounts()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   // get the actively bonded amount
   const activeUnit = planckToUnitBn(active, units)
 

--- a/packages/app/src/library/Graphs/AveragePayoutLine.tsx
+++ b/packages/app/src/library/Graphs/AveragePayoutLine.tsx
@@ -13,7 +13,7 @@ import {
   Title,
   Tooltip,
 } from 'chart.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { useThemeValues } from 'contexts/ThemeValues'
 import { Line } from 'react-chartjs-2'
@@ -45,9 +45,9 @@ export const AveragePayoutLine = ({
   inPool,
 }: AveragePayoutLineProps) => {
   const { t } = useTranslation('app')
-  const { getThemeValue } = useThemeValues()
   const { network } = useNetwork()
-  const { unit, units } = getNetworkData(network)
+  const { getThemeValue } = useThemeValues()
+  const { unit, units } = getStakingChainData(network)
 
   const staking = nominating || inPool
   const inPoolOnly = !nominating && inPool

--- a/packages/app/src/library/Graphs/PayoutBar.tsx
+++ b/packages/app/src/library/Graphs/PayoutBar.tsx
@@ -14,7 +14,7 @@ import {
   Title,
   Tooltip,
 } from 'chart.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { useThemeValues } from 'contexts/ThemeValues'
 import { format, fromUnixTime } from 'date-fns'
@@ -47,7 +47,7 @@ export const PayoutBar = ({
   const { i18n, t } = useTranslation('app')
   const { getThemeValue } = useThemeValues()
   const { network } = useNetwork()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const staking = nominating || inPool
 
   // Get formatted rewards data

--- a/packages/app/src/library/Graphs/PayoutLine.tsx
+++ b/packages/app/src/library/Graphs/PayoutLine.tsx
@@ -14,7 +14,7 @@ import {
   Title,
   Tooltip,
 } from 'chart.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { useThemeValues } from 'contexts/ThemeValues'
 import { format, fromUnixTime } from 'date-fns'
@@ -50,7 +50,7 @@ export const PayoutLine = ({
   const { i18n, t } = useTranslation()
   const { network } = useNetwork()
   const { getThemeValue } = useThemeValues()
-  const { unit } = getNetworkData(network)
+  const { unit } = getStakingChainData(network)
 
   // Format reward points as an array of strings, or an empty array if syncing
   const dataset = syncing

--- a/packages/app/src/library/ListItem/Labels/EraStatus.tsx
+++ b/packages/app/src/library/ListItem/Labels/EraStatus.tsx
@@ -3,7 +3,7 @@
 
 import { capitalizeFirstLetter } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useSyncing } from 'hooks/useSyncing'
@@ -17,7 +17,7 @@ export const EraStatus = ({ address, noMargin, status }: EraStatusProps) => {
   const { syncing } = useSyncing()
   const { network } = useNetwork()
   const { getValidatorTotalStake } = useValidators()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   // Fallback to `waiting` status if still syncing.
   const validatorStatus = syncing ? 'waiting' : status

--- a/packages/app/src/library/ListItem/Labels/NominationStatus.tsx
+++ b/packages/app/src/library/ListItem/Labels/NominationStatus.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { useStaking } from 'contexts/Staking'
 import { useSyncing } from 'hooks/useSyncing'
@@ -24,7 +24,7 @@ export const NominationStatus = ({
     eraStakers: { activeAccountOwnStake, stakers },
   } = useStaking()
   const { syncing } = useSyncing(['era-stakers'])
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   let stakedAmount = new BigNumber(0)
   if (bondFor === 'nominator') {

--- a/packages/app/src/library/ListItem/Labels/PoolBonded.tsx
+++ b/packages/app/src/library/ListItem/Labels/PoolBonded.tsx
@@ -3,7 +3,7 @@
 
 import { getChainIcons } from 'assets'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { useTooltip } from 'contexts/Tooltip'
 import { useTranslation } from 'react-i18next'
@@ -16,7 +16,7 @@ export const PoolBonded = ({ pool }: { pool: BondedPool }) => {
   const { t } = useTranslation('app')
   const { network } = useNetwork()
   const { setTooltipTextAndOpen } = useTooltip()
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
 
   const tooltipText = t('bonded')
   const { points } = pool

--- a/packages/app/src/library/ListItem/Labels/PoolMemberBonded.tsx
+++ b/packages/app/src/library/ListItem/Labels/PoolMemberBonded.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import type { FetchedPoolMember } from 'contexts/Pools/PoolMembers/types'
 import { ValidatorStatusWrapper } from 'library/ListItem/Wrappers'
@@ -12,7 +12,7 @@ import { planckToUnitBn } from 'utils'
 export const PoolMemberBonded = ({ member }: { member: FetchedPoolMember }) => {
   const { t } = useTranslation('app')
   const { network } = useNetwork()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   let bonded = new BigNumber(0)
   let totalUnbonding = new BigNumber(0)

--- a/packages/app/src/library/MainFooter/TokenPrice.tsx
+++ b/packages/app/src/library/MainFooter/TokenPrice.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useCurrency } from 'contexts/Currency'
 import { useNetwork } from 'contexts/Network'
 import { useTokenPrices } from 'contexts/TokenPrice'
@@ -10,7 +10,7 @@ export const TokenPrice = () => {
   const { network } = useNetwork()
   const { currency } = useCurrency()
   const { price, change } = useTokenPrices()
-  const { unit } = getNetworkData(network)
+  const { unit } = getStakingChainData(network)
   return (
     <>
       <div className="stat">

--- a/packages/app/src/library/PayeeInput/index.tsx
+++ b/packages/app/src/library/PayeeInput/index.tsx
@@ -5,7 +5,7 @@ import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Polkicon } from '@w3ux/react-polkicon'
 import { formatAccountSs58, isValidAddress, remToUnit } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useNetwork } from 'contexts/Network'
@@ -26,7 +26,7 @@ export const PayeeInput = ({
   const { accounts } = useImportedAccounts()
   const { activeAddress } = useActiveAccounts()
 
-  const { ss58 } = getNetworkData(network)
+  const { ss58 } = getStakingChainData(network)
   const accountMeta = accounts.find((a) => a.address === activeAddress)
 
   // store whether account value is valid.

--- a/packages/app/src/library/SubmitTx/ManualSign/Vault/SignPrompt.tsx
+++ b/packages/app/src/library/SubmitTx/ManualSign/Vault/SignPrompt.tsx
@@ -6,7 +6,7 @@ import {
   faChevronRight,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { getDefaultBalancesChain } from 'consts/util'
+import { getStakingChain } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { hexToU8a } from 'dedot/utils'
@@ -26,7 +26,7 @@ export const SignPrompt = ({
   const { network } = useNetwork()
   const { getChainSpec } = useApi()
   const { t } = useTranslation('app')
-  const { genesisHash } = getChainSpec(getDefaultBalancesChain(network))
+  const { genesisHash } = getChainSpec(getStakingChain(network))
 
   // Whether user is on sign or submit stage.
   const [stage, setStage] = useState<number>(1)

--- a/packages/app/src/library/SubmitTx/ManualSign/Vault/SignPrompt.tsx
+++ b/packages/app/src/library/SubmitTx/ManualSign/Vault/SignPrompt.tsx
@@ -6,6 +6,7 @@ import {
   faChevronRight,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { getDefaultBalancesChain } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { hexToU8a } from 'dedot/utils'
@@ -25,7 +26,7 @@ export const SignPrompt = ({
   const { network } = useNetwork()
   const { getChainSpec } = useApi()
   const { t } = useTranslation('app')
-  const { genesisHash } = getChainSpec(network)
+  const { genesisHash } = getChainSpec(getDefaultBalancesChain(network))
 
   // Whether user is on sign or submit stage.
   const [stage, setStage] = useState<number>(1)

--- a/packages/app/src/library/SubmitTx/index.tsx
+++ b/packages/app/src/library/SubmitTx/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useNetwork } from 'contexts/Network'
@@ -37,7 +37,7 @@ export const SubmitTx = ({
   const { activeAddress, activeProxy } = useActiveAccounts()
   const { getAccount, requiresManualSign } = useImportedAccounts()
 
-  const { unit } = getNetworkData(network)
+  const { unit } = getStakingChainData(network)
   const txSubmission = getTxSubmission(uid)
   const from = txSubmission?.from || null
   const fee = txSubmission?.fee || 0n

--- a/packages/app/src/overlay/canvas/CreatePool/Summary/index.tsx
+++ b/packages/app/src/overlay/canvas/CreatePool/Summary/index.tsx
@@ -5,7 +5,7 @@ import { faCheckCircle } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { unitToPlanck } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
@@ -36,7 +36,7 @@ export const Summary = ({ section }: SetupStepProps) => {
   const { getPoolSetup, removePoolSetup } = usePoolSetups()
   const { activeAddress, activeProxy } = useActiveAccounts()
   const { queryBondedPool, addToBondedPools } = useBondedPools()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   const poolId = lastPoolId + 1
   const setup = getPoolSetup(activeAddress)

--- a/packages/app/src/overlay/canvas/NominatorSetup/Summary/index.tsx
+++ b/packages/app/src/overlay/canvas/NominatorSetup/Summary/index.tsx
@@ -5,7 +5,7 @@ import { faCheckCircle } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ellipsisFn, unitToPlanck } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
@@ -43,7 +43,7 @@ export const Summary = ({
   const { accountHasSigner } = useImportedAccounts()
   const { activeAddress, activeProxy } = useActiveAccounts()
   const { getNominatorSetup, removeNominatorSetup } = useNominatorSetups()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   // Track whether bond is valid
   const [bondValid, setBondValid] = useState<boolean>(false)

--- a/packages/app/src/overlay/canvas/Pool/Overview/JoinForm.tsx
+++ b/packages/app/src/overlay/canvas/Pool/Overview/JoinForm.tsx
@@ -3,7 +3,7 @@
 
 import { planckToUnit, unitToPlanck } from '@w3ux/utils'
 import type BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
@@ -39,7 +39,7 @@ export const JoinForm = ({ bondedPool }: OverviewSectionProps) => {
   const { getSignerWarnings } = useSignerWarnings()
   const { getTransferOptions } = useTransferOptions()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const largestTxFee = useBondGreatestFee({ bondFor: 'pool' })
 
   const {

--- a/packages/app/src/overlay/canvas/Pool/Overview/Performance/index.tsx
+++ b/packages/app/src/overlay/canvas/Pool/Overview/Performance/index.tsx
@@ -13,7 +13,7 @@ import {
   Title,
   Tooltip,
 } from 'chart.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { usePlugins } from 'contexts/Plugins'
@@ -44,7 +44,7 @@ export const Performance = ({ bondedPool }: OverviewSectionProps) => {
   const { network } = useNetwork()
   const { containerRefs } = useUi()
   const { pluginEnabled } = usePlugins()
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
   // Ref to the graph container
   const graphInnerRef = useRef<HTMLDivElement | null>(null)
 

--- a/packages/app/src/overlay/canvas/Pool/Overview/Stats.tsx
+++ b/packages/app/src/overlay/canvas/Pool/Overview/Stats.tsx
@@ -3,7 +3,7 @@
 
 import { getChainIcons } from 'assets'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { useStaking } from 'contexts/Staking'
@@ -23,7 +23,7 @@ export const Stats = ({
   const { eraStakers } = useStaking()
   const { isReady, serviceApi } = useApi()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const Token = getChainIcons(network).token
   const isActive = eraStakers.stakers.find((staker) =>
     staker.others.find((other) => other.who === bondedPool.addresses.stash)

--- a/packages/app/src/overlay/canvas/Pool/Preloader.tsx
+++ b/packages/app/src/overlay/canvas/Pool/Preloader.tsx
@@ -3,7 +3,7 @@
 
 import { capitalizeFirstLetter } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { useBondedPools } from 'contexts/Pools/BondedPools'
@@ -20,7 +20,7 @@ export const Preloader = () => {
   const {
     poolsConfig: { counterForPoolMembers },
   } = useApi()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   let totalPoolPoints = new BigNumber(0)
   bondedPools.forEach((b: BondedPool) => {

--- a/packages/app/src/overlay/canvas/PoolMembers/Prompts/UnbondMember.tsx
+++ b/packages/app/src/overlay/canvas/PoolMembers/Prompts/UnbondMember.tsx
@@ -4,7 +4,7 @@
 import { Polkicon } from '@w3ux/react-polkicon'
 import { ellipsisFn } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
@@ -37,7 +37,7 @@ export const UnbondMember = ({
   const { activeAddress } = useActiveAccounts()
   const { erasToSeconds } = useErasToTimeLeft()
   const { getSignerWarnings } = useSignerWarnings()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   const { points } = member
   const { bondDuration } = getConsts(network)

--- a/packages/app/src/overlay/canvas/PoolMembers/Prompts/WithdrawMember.tsx
+++ b/packages/app/src/overlay/canvas/PoolMembers/Prompts/WithdrawMember.tsx
@@ -4,7 +4,7 @@
 import { Polkicon } from '@w3ux/react-polkicon'
 import { ellipsisFn } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
@@ -37,7 +37,7 @@ export const WithdrawMember = ({
   const { getConsts, activeEra } = useApi()
   const { activeAddress } = useActiveAccounts()
   const { getSignerWarnings } = useSignerWarnings()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const { historyDepth } = getConsts(network)
   const { unbondingEras, points } = member
 

--- a/packages/app/src/overlay/canvas/ValidatorMetrics/Rewards/ActiveGraph.tsx
+++ b/packages/app/src/overlay/canvas/ValidatorMetrics/Rewards/ActiveGraph.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { planckToUnit } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { PayoutLine } from 'library/Graphs/PayoutLine'
 import { useValidatorRewards } from 'plugin-staking-api'
 import type { NetworkId } from 'types'
@@ -26,7 +26,7 @@ export const ActiveGraph = ({
     validator,
     fromEra,
   })
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
 
   const list =
     loading || error || data?.validatorRewards === undefined

--- a/packages/app/src/overlay/canvas/ValidatorMetrics/index.tsx
+++ b/packages/app/src/overlay/canvas/ValidatorMetrics/index.tsx
@@ -5,7 +5,7 @@ import { useSize } from '@w3ux/hooks'
 import { Polkicon } from '@w3ux/react-polkicon'
 import { getChainIcons } from 'assets'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { usePlugins } from 'contexts/Plugins'
@@ -47,7 +47,7 @@ export const ValidatorMetrics = () => {
   const { containerRefs } = useUi()
   const { pluginEnabled } = usePlugins()
   const { getValidators } = useValidators()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   const Token = getChainIcons(network).token
   const validator = options!.validator

--- a/packages/app/src/overlay/modals/Accounts/Account.tsx
+++ b/packages/app/src/overlay/modals/Accounts/Account.tsx
@@ -10,7 +10,7 @@ import { ExtensionIcons } from '@w3ux/extension-assets/util'
 import { Polkicon } from '@w3ux/react-polkicon'
 import { ellipsisFn, planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useNetwork } from 'contexts/Network'
@@ -39,7 +39,7 @@ export const AccountButton = ({
   } = useActiveAccounts()
   const { network } = useNetwork()
   const { setModalStatus } = useOverlay().modal
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   // Accumulate account data.
   const meta = getAccount(address || '')

--- a/packages/app/src/overlay/modals/BalanceTest/index.tsx
+++ b/packages/app/src/overlay/modals/BalanceTest/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { unitToPlanck } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
@@ -18,7 +18,7 @@ export const BalanceTest = () => {
   const { newBatchCall } = useBatchCall()
   const { activeAddress } = useActiveAccounts()
   const { setModalStatus } = useOverlay().modal
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
 
   const getTx = () => {
     if (!activeAddress) {

--- a/packages/app/src/overlay/modals/Bond/index.tsx
+++ b/packages/app/src/overlay/modals/Bond/index.tsx
@@ -3,7 +3,7 @@
 
 import { planckToUnit, unitToPlanck } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useBalances } from 'contexts/Balances'
@@ -35,7 +35,7 @@ export const Bond = () => {
   const { getPendingPoolRewards } = useBalances()
   const { getSignerWarnings } = useSignerWarnings()
   const { feeReserve, getTransferOptions } = useTransferOptions()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   const { bondFor } = options
   const isStaking = bondFor === 'nominator'

--- a/packages/app/src/overlay/modals/ClaimPayouts/Forms.tsx
+++ b/packages/app/src/overlay/modals/ClaimPayouts/Forms.tsx
@@ -4,7 +4,7 @@
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import { planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
@@ -38,7 +38,7 @@ export const Forms = forwardRef(
     const { activeAddress } = useActiveAccounts()
     const { getSignerWarnings } = useSignerWarnings()
     const { unclaimedRewards, setUnclaimedRewards } = usePayouts()
-    const { unit, units } = getNetworkData(network)
+    const { unit, units } = getStakingChainData(network)
 
     // Get the total payout amount
     const totalPayout =

--- a/packages/app/src/overlay/modals/ClaimPayouts/Item.tsx
+++ b/packages/app/src/overlay/modals/ClaimPayouts/Item.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { useTranslation } from 'react-i18next'
 import { ButtonSubmit } from 'ui-buttons'
@@ -18,7 +18,7 @@ export const Item = ({
 }: ItemProps) => {
   const { t } = useTranslation('modals')
   const { network } = useNetwork()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const totalPayout = getTotalPayout(validators)
   const numPayouts = validators.length
 

--- a/packages/app/src/overlay/modals/ClaimReward/index.tsx
+++ b/packages/app/src/overlay/modals/ClaimReward/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { planckToUnit } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useBalances } from 'contexts/Balances'
@@ -34,7 +34,7 @@ export const ClaimReward = () => {
   const { getSignerWarnings } = useSignerWarnings()
 
   const { claimType } = options
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const pendingRewards = getPendingPoolRewards(activeAddress)
 
   // ensure selected payout is valid

--- a/packages/app/src/overlay/modals/ImportAccounts/Ledger.tsx
+++ b/packages/app/src/overlay/modals/ImportAccounts/Ledger.tsx
@@ -8,7 +8,7 @@ import { useHardwareAccounts } from '@w3ux/react-connect-kit'
 import { Polkicon } from '@w3ux/react-polkicon'
 import type { HardwareAccount, HardwareAccountSource } from '@w3ux/types'
 import { ellipsisFn, setStateWithRef } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useOtherAccounts } from 'contexts/Connect/OtherAccounts'
 import { useLedgerHardware } from 'contexts/LedgerHardware'
 import type {
@@ -46,7 +46,7 @@ export const Ledger = () => {
   const { setModalResize } = useOverlay().modal
   const { renameOtherAccount, addOtherAccounts, forgetOtherAccounts } =
     useOtherAccounts()
-  const { ss58 } = getNetworkData(network)
+  const { ss58 } = getStakingChainData(network)
   const source: HardwareAccountSource = 'ledger'
 
   // Store addresses retreived from Ledger device. Defaults to local addresses

--- a/packages/app/src/overlay/modals/ImportAccounts/Vault.tsx
+++ b/packages/app/src/overlay/modals/ImportAccounts/Vault.tsx
@@ -6,7 +6,7 @@ import PolkadotVaultSVG from '@w3ux/extension-assets/PolkadotVault.svg?react'
 import { useHardwareAccounts } from '@w3ux/react-connect-kit'
 import { Polkicon } from '@w3ux/react-polkicon'
 import type { HardwareAccountSource } from '@w3ux/types'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useOtherAccounts } from 'contexts/Connect/OtherAccounts'
 import { useNetwork } from 'contexts/Network'
 import { QrReader } from 'library/QrReader'
@@ -30,7 +30,7 @@ export const Vault = () => {
   const { setModalResize } = useOverlay().modal
   const { renameOtherAccount, addOtherAccounts, forgetOtherAccounts } =
     useOtherAccounts()
-  const { ss58 } = getNetworkData(network)
+  const { ss58 } = getStakingChainData(network)
   const source: HardwareAccountSource = 'vault'
 
   // Whether the import account button is active

--- a/packages/app/src/overlay/modals/LeavePool/index.tsx
+++ b/packages/app/src/overlay/modals/LeavePool/index.tsx
@@ -3,7 +3,7 @@
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import { planckToUnit } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useBalances } from 'contexts/Balances'
@@ -43,7 +43,7 @@ export const LeavePool = ({
   const { getTransferOptions } = useTransferOptions()
   const { getStakingLedger, getPendingPoolRewards } = useBalances()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const allTransferOptions = getTransferOptions(activeAddress)
   const { active: activeBn } = allTransferOptions.pool
   const { bondDuration } = getConsts(network)

--- a/packages/app/src/overlay/modals/ManageFastUnstake/index.tsx
+++ b/packages/app/src/overlay/modals/ManageFastUnstake/index.tsx
@@ -3,7 +3,7 @@
 
 import { planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useFastUnstake } from 'contexts/FastUnstake'
@@ -40,7 +40,7 @@ export const ManageFastUnstake = () => {
   const { counterForQueue, queueDeposit, fastUnstakeStatus, exposed } =
     useFastUnstake()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const { bondDuration, fastUnstakeDeposit } = getConsts(network)
   const allTransferOptions = getTransferOptions(activeAddress)
   const { nominate, transferrableBalance } = allTransferOptions

--- a/packages/app/src/overlay/modals/ManagePool/Forms/ClaimCommission/index.tsx
+++ b/packages/app/src/overlay/modals/ManagePool/Forms/ClaimCommission/index.tsx
@@ -3,7 +3,7 @@
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
@@ -36,7 +36,7 @@ export const ClaimCommission = ({
   const { isOwner, activePool } = useActivePool()
   const { getSignerWarnings } = useSignerWarnings()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const poolId = activePool?.id
   const pendingCommission = new BigNumber(
     activePool?.rewardPool?.totalCommissionPending || 0

--- a/packages/app/src/overlay/modals/RewardCalculator/index.tsx
+++ b/packages/app/src/overlay/modals/RewardCalculator/index.tsx
@@ -4,7 +4,7 @@
 import { faToggleOff, faToggleOn } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { getChainIcons } from 'assets'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useAverageRewardRate } from 'hooks/useAverageRewardRate'
@@ -28,7 +28,7 @@ export const RewardCalculator = () => {
   const { avgCommission } = useValidators()
   const { getAverageRewardRate } = useAverageRewardRate()
 
-  const { unit } = getNetworkData(network)
+  const { unit } = getStakingChainData(network)
   const Token = getChainIcons(network).token
   const { currency } = config.options
   const { avgRateBeforeCommission } = getAverageRewardRate(false)

--- a/packages/app/src/overlay/modals/Unbond/index.tsx
+++ b/packages/app/src/overlay/modals/Unbond/index.tsx
@@ -3,7 +3,7 @@
 
 import { planckToUnit, unitToPlanck } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useBalances } from 'contexts/Balances'
@@ -52,7 +52,7 @@ export const Unbond = () => {
 
   const { bondFor } = options
   const { bondDuration } = getConsts(network)
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const pendingRewards = getPendingPoolRewards(activeAddress)
 
   const bondDurationFormatted = timeleftAsString(

--- a/packages/app/src/overlay/modals/UnlockChunks/Chunk.tsx
+++ b/packages/app/src/overlay/modals/UnlockChunks/Chunk.tsx
@@ -3,7 +3,7 @@
 
 import { useTimeLeft } from '@w3ux/hooks'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
@@ -32,7 +32,7 @@ export const Chunk = ({ chunk, bondFor, onRebond }: ChunkProps) => {
     depsFormat: [i18n.resolvedLanguage],
   })
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const isStaking = bondFor === 'nominator'
   const { era, value } = chunk
   const left = new BigNumber(era).minus(activeEra.index)

--- a/packages/app/src/overlay/modals/UnlockChunks/Forms.tsx
+++ b/packages/app/src/overlay/modals/UnlockChunks/Forms.tsx
@@ -4,7 +4,7 @@
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import { planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
@@ -48,7 +48,7 @@ export const Forms = forwardRef(
     const { getSignerWarnings } = useSignerWarnings()
     const { removeFavorite: removeFavoritePool } = useFavoritePools()
 
-    const { unit, units } = getNetworkData(network)
+    const { unit, units } = getStakingChainData(network)
     const { bondFor, poolClosure } = options || {}
     const { historyDepth } = getConsts(network)
 

--- a/packages/app/src/overlay/modals/UnlockChunks/Overview.tsx
+++ b/packages/app/src/overlay/modals/UnlockChunks/Overview.tsx
@@ -5,7 +5,7 @@ import { faCheckCircle, faClock } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import type { UnlockChunk } from 'contexts/Balances/types'
 import { useNetwork } from 'contexts/Network'
@@ -44,7 +44,7 @@ export const Overview = forwardRef(
     const { isFastUnstaking } = useUnstaking()
     const { erasToSeconds } = useErasToTimeLeft()
 
-    const { unit, units } = getNetworkData(network)
+    const { unit, units } = getStakingChainData(network)
     const bondDurationFormatted = timeleftAsString(
       t,
       getUnixTime(new Date()) + 1,

--- a/packages/app/src/overlay/modals/Unstake/index.tsx
+++ b/packages/app/src/overlay/modals/Unstake/index.tsx
@@ -3,7 +3,7 @@
 
 import { planckToUnit, unitToPlanck } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useBalances } from 'contexts/Balances'
@@ -37,7 +37,7 @@ export const Unstake = () => {
   const { setModalStatus, setModalResize } = useOverlay().modal
 
   const { bondDuration } = getConsts(network)
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const nominations = getNominations(activeAddress)
   const allTransferOptions = getTransferOptions(activeAddress)
   const { active } = allTransferOptions.nominate

--- a/packages/app/src/overlay/modals/UpdateReserve/index.tsx
+++ b/packages/app/src/overlay/modals/UpdateReserve/index.tsx
@@ -5,7 +5,7 @@ import { faLock } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { planckToUnit, unitToPlanck } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useHelp } from 'contexts/Help'
@@ -33,7 +33,7 @@ export const UpdateReserve = () => {
   const { feeReserve, setFeeReserveBalance, getTransferOptions } =
     useTransferOptions()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const { edReserved } = getTransferOptions(activeAddress)
   const minReserve = new BigNumber(planckToUnit(edReserved, units))
   const maxReserve = minReserve.plus(

--- a/packages/app/src/pages/Nominate/Active/ManageBond.tsx
+++ b/packages/app/src/pages/Nominate/Active/ManageBond.tsx
@@ -11,7 +11,7 @@ import { Odometer } from '@w3ux/react-odometer'
 import { minDecimalPlaces, planckToUnit } from '@w3ux/utils'
 import { getChainIcons } from 'assets'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useBalances } from 'contexts/Balances'
@@ -51,7 +51,7 @@ export const ManageBond = () => {
   const { exposed, fastUnstakeStatus } = useFastUnstake()
 
   const { ledger } = getStakingLedger(activeAddress)
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
   const Token = getChainIcons(network).token
   const active = ledger?.active || 0n
   const allTransferOptions = getTransferOptions(activeAddress)

--- a/packages/app/src/pages/Nominate/Active/Stats/MinimumActiveStake.tsx
+++ b/packages/app/src/pages/Nominate/Active/Stats/MinimumActiveStake.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { Number } from 'library/StatCards/Number'
@@ -13,7 +13,7 @@ export const MinimumActiveStake = () => {
   const { t } = useTranslation('pages')
   const { network } = useNetwork()
   const { minNominatorBond, minimumActiveStake } = useApi().stakingMetrics
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const minToEarnRewards = BigNumber.max(minNominatorBond, minimumActiveStake)
 
   const params = {

--- a/packages/app/src/pages/Nominate/Active/Stats/MinimumNominatorBond.tsx
+++ b/packages/app/src/pages/Nominate/Active/Stats/MinimumNominatorBond.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { planckToUnit } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { Number } from 'library/StatCards/Number'
@@ -12,7 +12,7 @@ export const MinimumNominatorBond = () => {
   const { t } = useTranslation('pages')
   const { network } = useNetwork()
   const { minNominatorBond } = useApi().stakingMetrics
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   const params = {
     label: t('minimumToNominate'),

--- a/packages/app/src/pages/Nominate/Active/Status/UnclaimedPayoutsStatus.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/UnclaimedPayoutsStatus.tsx
@@ -3,7 +3,7 @@
 
 import { faCircleDown } from '@fortawesome/free-solid-svg-icons'
 import { minDecimalPlaces, planckToUnit } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
@@ -25,7 +25,7 @@ export const UnclaimedPayoutsStatus = ({ dimmed }: { dimmed: boolean }) => {
   const { pluginEnabled } = usePlugins()
   const { activeAddress } = useActiveAccounts()
   const { isReadOnlyAccount } = useImportedAccounts()
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
   return (
     <Stat
       label={t('pendingPayouts', { ns: 'pages' })}

--- a/packages/app/src/pages/Nominate/Active/UnstakePrompts.tsx
+++ b/packages/app/src/pages/Nominate/Active/UnstakePrompts.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { faBolt, faLockOpen } from '@fortawesome/free-solid-svg-icons'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useNetwork } from 'contexts/Network'
 import { useStaking } from 'contexts/Staking'
@@ -26,7 +26,7 @@ export const UnstakePrompts = () => {
   const { activeAddress } = useActiveAccounts()
   const { isFastUnstaking, isUnstaking, getFastUnstakeText } = useUnstaking()
 
-  const { unit } = getNetworkData(network)
+  const { unit } = getStakingChainData(network)
   const { getTransferOptions } = useTransferOptions()
   const { active, totalUnlockChunks, totalUnlocked, totalUnlocking } =
     getTransferOptions(activeAddress).nominate

--- a/packages/app/src/pages/Nominate/NominationGeo/Stats/AnalyzedPayouts.tsx
+++ b/packages/app/src/pages/Nominate/NominationGeo/Stats/AnalyzedPayouts.tsx
@@ -5,7 +5,7 @@ import { useNetwork } from 'contexts/Network'
 import { Number } from 'library/StatCards/Number'
 import { useTranslation } from 'react-i18next'
 
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import type { AnalyzedPayoutsProps } from '../types'
 
 // We simply report the size of payouts that have been analyzed for decentralization purpose
@@ -13,7 +13,7 @@ import type { AnalyzedPayoutsProps } from '../types'
 export const AnalyzedPayouts = ({ data }: AnalyzedPayoutsProps) => {
   const { t } = useTranslation('pages')
   const { network } = useNetwork()
-  const { unit } = getNetworkData(network)
+  const { unit } = getStakingChainData(network)
 
   const params = {
     label: t('totalPayoutsAnalysed'),

--- a/packages/app/src/pages/Overview/AccountBalance/BalanceChart.tsx
+++ b/packages/app/src/pages/Overview/AccountBalance/BalanceChart.tsx
@@ -5,7 +5,7 @@ import { faCheck, faCheckDouble } from '@fortawesome/free-solid-svg-icons'
 import { planckToUnit } from '@w3ux/utils'
 import { getChainIcons } from 'assets'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useBalances } from 'contexts/Balances'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
@@ -34,7 +34,7 @@ export const BalanceChart = () => {
   const { syncing } = useSyncing(['initialization'])
   const { accountHasSigner } = useImportedAccounts()
   const { feeReserve, getTransferOptions } = useTransferOptions()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const Token = getChainIcons(network).token
 
   const stakingLedger = getStakingLedger(activeAddress)

--- a/packages/app/src/pages/Overview/AccountBalance/BalanceLinks.tsx
+++ b/packages/app/src/pages/Overview/AccountBalance/BalanceLinks.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons'
+import { getSubscanBalanceChainId } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useNetwork } from 'contexts/Network'
 import { useStaking } from 'contexts/Staking'
@@ -25,7 +26,7 @@ export const BalanceLinks = () => {
           lg
           onClick={() =>
             window.open(
-              `https://${network}.subscan.io/account/${activeAddress}`,
+              `https://${getSubscanBalanceChainId(network)}.subscan.io/account/${activeAddress}`,
               '_blank'
             )
           }

--- a/packages/app/src/pages/Overview/NetworkSats/Announcements.tsx
+++ b/packages/app/src/pages/Overview/NetworkSats/Announcements.tsx
@@ -5,7 +5,7 @@ import { faBullhorn as faBack } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { capitalizeFirstLetter, planckToUnit, sortWithNull } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { useBondedPools } from 'contexts/Pools/BondedPools'
@@ -24,7 +24,7 @@ export const Announcements = () => {
     stakingMetrics: { totalStaked, lastReward },
   } = useApi()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const lastRewardUnit = new BigNumber(planckToUnit(lastReward || 0, units))
 
   let totalPoolPoints = new BigNumber(0)

--- a/packages/app/src/pages/Overview/Payouts/index.tsx
+++ b/packages/app/src/pages/Overview/Payouts/index.tsx
@@ -4,7 +4,7 @@
 import { useSize } from '@w3ux/hooks'
 import { getChainIcons } from 'assets'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useCurrency } from 'contexts/Currency'
 import { useNetwork } from 'contexts/Network'
 import { usePlugins } from 'contexts/Plugins'
@@ -36,7 +36,7 @@ export const Payouts = () => {
   const { currency } = useCurrency()
   const { pluginEnabled } = usePlugins()
 
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
   const Token = getChainIcons(network).token
   const staking = !inSetup() || inPool
   const notStaking = !syncing && !staking

--- a/packages/app/src/pages/Overview/Stats/SupplyStaked.tsx
+++ b/packages/app/src/pages/Overview/Stats/SupplyStaked.tsx
@@ -12,13 +12,10 @@ import { useTranslation } from 'react-i18next'
 export const SupplyStaked = () => {
   const { t } = useTranslation('pages')
   const {
-    relayMetrics,
-    stakingMetrics: { lastTotalStake },
+    stakingMetrics: { lastTotalStake, totalIssuance },
   } = useApi()
   const { network } = useNetwork()
-
   const { unit, units } = getStakingChainData(network)
-  const { totalIssuance } = relayMetrics
 
   // total supply as percent.
   const totalIssuanceUnit = new BigNumber(planckToUnit(totalIssuance, units))

--- a/packages/app/src/pages/Overview/Stats/SupplyStaked.tsx
+++ b/packages/app/src/pages/Overview/Stats/SupplyStaked.tsx
@@ -3,7 +3,7 @@
 
 import { planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { Pie } from 'library/StatCards/Pie'
@@ -17,7 +17,7 @@ export const SupplyStaked = () => {
   } = useApi()
   const { network } = useNetwork()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const { totalIssuance } = relayMetrics
 
   // total supply as percent.

--- a/packages/app/src/pages/Pools/ManageBond.tsx
+++ b/packages/app/src/pages/Pools/ManageBond.tsx
@@ -6,7 +6,7 @@ import { Odometer } from '@w3ux/react-odometer'
 import { minDecimalPlaces, planckToUnit } from '@w3ux/utils'
 import { getChainIcons } from 'assets'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
 import { useHelp } from 'contexts/Help'
@@ -32,7 +32,7 @@ export const ManageBond = () => {
   const { getTransferOptions } = useTransferOptions()
   const { isBonding, isMember, activePool, isDepositor } = useActivePool()
 
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
   const Token = getChainIcons(network).token
   const allTransferOptions = getTransferOptions(activeAddress)
   const {

--- a/packages/app/src/pages/Pools/PoolStats/Announcements.tsx
+++ b/packages/app/src/pages/Pools/PoolStats/Announcements.tsx
@@ -4,7 +4,7 @@
 import { faBullhorn as faBack } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import BigNumber from 'bignumber.js'
-import { getDefaultBalancesChain, getNetworkData } from 'consts/util'
+import { getDefaultBalancesChain, getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { useActivePool } from 'contexts/Pools/ActivePool'
@@ -20,7 +20,7 @@ export const Announcements = () => {
   const { getChainSpec } = useApi()
   const { activePool } = useActivePool()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const { rewardAccountBalance } = activePool || {}
   const { totalRewardsClaimed } = activePool?.rewardPool || {}
   const { existentialDeposit } = getChainSpec(getDefaultBalancesChain(network))

--- a/packages/app/src/pages/Pools/PoolStats/Announcements.tsx
+++ b/packages/app/src/pages/Pools/PoolStats/Announcements.tsx
@@ -4,7 +4,7 @@
 import { faBullhorn as faBack } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import BigNumber from 'bignumber.js'
-import { getDefaultBalancesChain, getStakingChainData } from 'consts/util'
+import { getStakingChain, getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { useActivePool } from 'contexts/Pools/ActivePool'
@@ -23,7 +23,7 @@ export const Announcements = () => {
   const { unit, units } = getStakingChainData(network)
   const { rewardAccountBalance } = activePool || {}
   const { totalRewardsClaimed } = activePool?.rewardPool || {}
-  const { existentialDeposit } = getChainSpec(getDefaultBalancesChain(network))
+  const { existentialDeposit } = getChainSpec(getStakingChain(network))
 
   // calculate the latest reward account balance
   const rewardPoolBalance = BigNumber.max(

--- a/packages/app/src/pages/Pools/PoolStats/Announcements.tsx
+++ b/packages/app/src/pages/Pools/PoolStats/Announcements.tsx
@@ -4,7 +4,7 @@
 import { faBullhorn as faBack } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getDefaultBalancesChain, getNetworkData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { useActivePool } from 'contexts/Pools/ActivePool'
@@ -23,7 +23,7 @@ export const Announcements = () => {
   const { unit, units } = getNetworkData(network)
   const { rewardAccountBalance } = activePool || {}
   const { totalRewardsClaimed } = activePool?.rewardPool || {}
-  const { existentialDeposit } = getChainSpec(network)
+  const { existentialDeposit } = getChainSpec(getDefaultBalancesChain(network))
 
   // calculate the latest reward account balance
   const rewardPoolBalance = BigNumber.max(

--- a/packages/app/src/pages/Pools/PoolStats/index.tsx
+++ b/packages/app/src/pages/Pools/PoolStats/index.tsx
@@ -3,7 +3,7 @@
 
 import BigNumber from 'bignumber.js'
 import { PerbillMultiplier } from 'consts'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { usePlugins } from 'contexts/Plugins'
 import { useActivePool } from 'contexts/Pools/ActivePool'
@@ -26,7 +26,7 @@ export const PoolStats = () => {
   const { activePool } = useActivePool()
   const { getCurrentCommission } = usePoolCommission()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const poolId = activePool?.id || 0
 
   const { state, points, memberCounter } = activePool?.bondedPool || {}

--- a/packages/app/src/pages/Pools/Roles/RoleEditInput/index.tsx
+++ b/packages/app/src/pages/Pools/Roles/RoleEditInput/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { formatAccountSs58, isValidAddress } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import type { FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -16,7 +16,7 @@ export const RoleEditInput = ({
 }: RoleEditInputProps) => {
   const { t } = useTranslation('pages')
   const { network } = useNetwork()
-  const { ss58 } = getNetworkData(network)
+  const { ss58 } = getStakingChainData(network)
 
   const processRoleEdit = (newAddress: string) => {
     let edit = {

--- a/packages/app/src/pages/Pools/Stats/MinCreateBond.tsx
+++ b/packages/app/src/pages/Pools/Stats/MinCreateBond.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { planckToUnit } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { Number } from 'library/StatCards/Number'
@@ -12,7 +12,7 @@ export const MinCreateBond = () => {
   const { t } = useTranslation('pages')
   const { network } = useNetwork()
   const { minCreateBond } = useApi().poolsConfig
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   const params = {
     label: t('minimumToCreatePool'),

--- a/packages/app/src/pages/Pools/Stats/MinJoinBond.tsx
+++ b/packages/app/src/pages/Pools/Stats/MinJoinBond.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { planckToUnit } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { Number } from 'library/StatCards/Number'
@@ -12,7 +12,7 @@ export const MinJoinBond = () => {
   const { t } = useTranslation('pages')
   const { network } = useNetwork()
   const { minJoinBond } = useApi().poolsConfig
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const params = {
     label: t('minimumToJoinPool'),
     value: parseFloat(planckToUnit(minJoinBond, units)),

--- a/packages/app/src/pages/Pools/Status/RewardsStatus.tsx
+++ b/packages/app/src/pages/Pools/Status/RewardsStatus.tsx
@@ -3,7 +3,7 @@
 
 import { faCircleDown, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { planckToUnit } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useBalances } from 'contexts/Balances'
@@ -26,7 +26,7 @@ export const RewardsStatus = ({ dimmed }: { dimmed: boolean }) => {
   const { syncing } = useSyncing(['active-pools'])
   const { isReadOnlyAccount } = useImportedAccounts()
 
-  const { units } = getNetworkData(network)
+  const { units } = getStakingChainData(network)
   const pendingRewards = getPendingPoolRewards(activeAddress)
   const minUnclaimedDisplay = 1000000n
 

--- a/packages/app/src/pages/Rewards/Overview/index.tsx
+++ b/packages/app/src/pages/Rewards/Overview/index.tsx
@@ -11,7 +11,7 @@ import { Odometer } from '@w3ux/react-odometer'
 import { minDecimalPlaces } from '@w3ux/utils'
 import { getChainIcons } from 'assets'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useCurrency } from 'contexts/Currency'
 import { useNetwork } from 'contexts/Network'
@@ -53,7 +53,7 @@ export const Overview = (props: PayoutHistoryProps) => {
   const { getAverageRewardRate } = useAverageRewardRate()
   const { avgRateBeforeCommission } = getAverageRewardRate(false)
 
-  const { unit } = getNetworkData(network)
+  const { unit } = getStakingChainData(network)
   const rewardRate = avgRateBeforeCommission.toNumber()
   const Token = getChainIcons(network).token
 

--- a/packages/app/src/pages/Rewards/RecentPayouts/PayoutList.tsx
+++ b/packages/app/src/pages/Rewards/RecentPayouts/PayoutList.tsx
@@ -5,7 +5,7 @@ import { faBars, faGripVertical } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ellipsisFn } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { ListProvider, useList } from 'contexts/List'
 import { useNetwork } from 'contexts/Network'
@@ -51,7 +51,7 @@ export const PayoutListInner = ({
     setListFormat,
     pagination: { page, setPage },
   } = useList()
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   // Manipulated list (ordering, filtering) of payouts
   const [payouts, setPayouts] = useState<RewardResults>(initialPayouts)

--- a/packages/app/src/pages/Rewards/Stats/LastEraPayout.tsx
+++ b/packages/app/src/pages/Rewards/Stats/LastEraPayout.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { planckToUnit } from '@w3ux/utils'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { Number } from 'library/StatCards/Number'
@@ -12,7 +12,7 @@ export const LastEraPayout = () => {
   const { t } = useTranslation('pages')
   const { network } = useNetwork()
   const { lastReward } = useApi().stakingMetrics
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
 
   const lastRewardUnit = parseFloat(planckToUnit(lastReward || 0, units))
 

--- a/packages/app/src/pages/Rewards/Stats/RewardTrend.tsx
+++ b/packages/app/src/pages/Rewards/Stats/RewardTrend.tsx
@@ -3,7 +3,7 @@
 
 import { planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import { getNetworkData } from 'consts/util'
+import { getStakingChainData } from 'consts/util'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useApi } from 'contexts/Api'
 import { useBalances } from 'contexts/Balances'
@@ -28,7 +28,7 @@ export const RewardTrend = () => {
   const { getStakingLedger } = useBalances()
   const { activeAddress } = useActiveAccounts()
 
-  const { unit, units } = getNetworkData(network)
+  const { unit, units } = getStakingChainData(network)
   const { poolMembership } = getStakingLedger(activeAddress)
   const eras = erasPerDay * 30
   // NOTE: 30 day duration in seconds

--- a/packages/consts/src/networks.ts
+++ b/packages/consts/src/networks.ts
@@ -30,8 +30,7 @@ export const NetworkList: Networks = {
     ss58: 0,
     defaultFeeReserve: 1000000000n,
     meta: {
-      defaultBalances: 'polkadot',
-      defaultTx: 'polkadot',
+      stakingChain: 'polkadot',
       subscanBalanceChainId: 'polkadot',
     },
   },
@@ -54,8 +53,7 @@ export const NetworkList: Networks = {
     ss58: 2,
     defaultFeeReserve: 50000000000n,
     meta: {
-      defaultBalances: 'kusama',
-      defaultTx: 'kusama',
+      stakingChain: 'kusama',
       subscanBalanceChainId: 'kusama',
     },
   },
@@ -77,8 +75,7 @@ export const NetworkList: Networks = {
     ss58: 42,
     defaultFeeReserve: 100000000000n,
     meta: {
-      defaultBalances: 'westmint',
-      defaultTx: 'westmint',
+      stakingChain: 'westmint',
       subscanBalanceChainId: 'assethub-westend',
     },
   },

--- a/packages/consts/src/networks.ts
+++ b/packages/consts/src/networks.ts
@@ -91,6 +91,7 @@ export const SystemChainList: Record<string, SystemChain> = {
     ss58: 0,
     units: 10,
     unit: 'DOT',
+    defaultFeeReserve: 1000000000n,
     endpoints: {
       lightClient: async () =>
         await import('@substrate/connect-known-chains/polkadot_people'),
@@ -106,6 +107,7 @@ export const SystemChainList: Record<string, SystemChain> = {
     ss58: 2,
     units: 12,
     unit: 'KSM',
+    defaultFeeReserve: 50000000000n,
     endpoints: {
       lightClient: async () =>
         await import('@substrate/connect-known-chains/ksmcc3_people'),
@@ -121,6 +123,7 @@ export const SystemChainList: Record<string, SystemChain> = {
     ss58: 42,
     units: 12,
     unit: 'WND',
+    defaultFeeReserve: 100000000000n,
     endpoints: {
       lightClient: async () =>
         await import('@substrate/connect-known-chains/westend_people'),
@@ -136,6 +139,7 @@ export const SystemChainList: Record<string, SystemChain> = {
     ss58: 0,
     units: 10,
     unit: 'DOT',
+    defaultFeeReserve: 1000000000n,
     endpoints: {
       lightClient: async () =>
         await import('@substrate/connect-known-chains/polkadot_asset_hub'),
@@ -155,6 +159,7 @@ export const SystemChainList: Record<string, SystemChain> = {
     ss58: 2,
     units: 12,
     unit: 'KSM',
+    defaultFeeReserve: 50000000000n,
     endpoints: {
       lightClient: async () =>
         await import('@substrate/connect-known-chains/ksmcc3_asset_hub'),
@@ -172,6 +177,7 @@ export const SystemChainList: Record<string, SystemChain> = {
     ss58: 42,
     units: 12,
     unit: 'WND',
+    defaultFeeReserve: 100000000000n,
     endpoints: {
       lightClient: async () =>
         await import('@substrate/connect-known-chains/westend2_asset_hub'),

--- a/packages/consts/src/networks.ts
+++ b/packages/consts/src/networks.ts
@@ -32,6 +32,7 @@ export const NetworkList: Networks = {
     meta: {
       defaultBalances: 'polkadot',
       defaultTx: 'polkadot',
+      subscanBalanceChainId: 'polkadot',
     },
   },
   kusama: {
@@ -55,6 +56,7 @@ export const NetworkList: Networks = {
     meta: {
       defaultBalances: 'kusama',
       defaultTx: 'kusama',
+      subscanBalanceChainId: 'kusama',
     },
   },
   westend: {
@@ -77,6 +79,7 @@ export const NetworkList: Networks = {
     meta: {
       defaultBalances: 'westmint',
       defaultTx: 'westmint',
+      subscanBalanceChainId: 'assethub-westend',
     },
   },
 }

--- a/packages/consts/src/networks.ts
+++ b/packages/consts/src/networks.ts
@@ -29,6 +29,10 @@ export const NetworkList: Networks = {
     units: 10,
     ss58: 0,
     defaultFeeReserve: 1000000000n,
+    meta: {
+      defaultBalances: 'polkadot',
+      defaultTx: 'polkadot',
+    },
   },
   kusama: {
     name: 'kusama',
@@ -48,6 +52,10 @@ export const NetworkList: Networks = {
     units: 12,
     ss58: 2,
     defaultFeeReserve: 50000000000n,
+    meta: {
+      defaultBalances: 'kusama',
+      defaultTx: 'kusama',
+    },
   },
   westend: {
     name: 'westend',
@@ -66,6 +74,10 @@ export const NetworkList: Networks = {
     units: 12,
     ss58: 42,
     defaultFeeReserve: 100000000000n,
+    meta: {
+      defaultBalances: 'westmint',
+      defaultTx: 'westmint',
+    },
   },
 }
 

--- a/packages/consts/src/util.ts
+++ b/packages/consts/src/util.ts
@@ -92,3 +92,11 @@ export const getEnabledNetworks = (): Networks =>
 // Checks if a network is enabled
 export const isNetworkEnabled = (network: NetworkId) =>
   Object.keys(getEnabledNetworks()).includes(network)
+
+// Get default chain for balances by network
+export const getDefaultBalancesChain = (network: NetworkId) =>
+  NetworkList[network].meta.defaultBalances
+
+// Get default chain for submitting transactions, by network
+export const getDefaultTxChain = (network: NetworkId) =>
+  NetworkList[network].meta.defaultTx

--- a/packages/consts/src/util.ts
+++ b/packages/consts/src/util.ts
@@ -28,11 +28,18 @@ export const isSupportedProxyCall = (
 }
 
 // Get network data from network list
-export const getNetworkData = (network: NetworkId) => NetworkList[network]
+export const getRelayChainData = (network: NetworkId) => NetworkList[network]
 
-// Get system chain data from network list
 export const getSystemChainData = (chain: SystemChainId) =>
   SystemChainList[chain]
+
+// Get staking chain data from either network list or system chain list
+export const getStakingChainData = (chain: SystemChainId | NetworkId) => {
+  if (Object.keys(SystemChainList).includes(chain)) {
+    return SystemChainList[chain as SystemChainId]
+  }
+  return NetworkList[chain as NetworkId]
+}
 
 // Get default rpc endpoints for a relay chain and accompanying system chains for a given network
 export const getDefaultRpcEndpoints = (network: NetworkId) => {

--- a/packages/consts/src/util.ts
+++ b/packages/consts/src/util.ts
@@ -100,3 +100,7 @@ export const getDefaultBalancesChain = (network: NetworkId) =>
 // Get default chain for submitting transactions, by network
 export const getDefaultTxChain = (network: NetworkId) =>
   NetworkList[network].meta.defaultTx
+
+// Get subscan balance chain id by network
+export const getSubscanBalanceChainId = (network: NetworkId) =>
+  NetworkList[network].meta.subscanBalanceChainId

--- a/packages/consts/src/util.ts
+++ b/packages/consts/src/util.ts
@@ -34,11 +34,18 @@ export const getSystemChainData = (chain: SystemChainId) =>
   SystemChainList[chain]
 
 // Get staking chain data from either network list or system chain list
-export const getStakingChainData = (chain: SystemChainId | NetworkId) => {
-  if (Object.keys(SystemChainList).includes(chain)) {
-    return SystemChainList[chain as SystemChainId]
+export const getStakingChainData = (network: NetworkId) => {
+  const relayChainData = NetworkList[network]
+  const stakingChain = relayChainData.meta.stakingChain
+
+  if (stakingChain === network) {
+    return relayChainData
   }
-  return NetworkList[chain as NetworkId]
+  if (Object.keys(SystemChainList).includes(stakingChain)) {
+    return SystemChainList[stakingChain]
+  }
+  // NOTE: fallback - should not happen
+  return relayChainData
 }
 
 // Get default rpc endpoints for a relay chain and accompanying system chains for a given network
@@ -100,13 +107,9 @@ export const getEnabledNetworks = (): Networks =>
 export const isNetworkEnabled = (network: NetworkId) =>
   Object.keys(getEnabledNetworks()).includes(network)
 
-// Get default chain for balances by network
-export const getDefaultBalancesChain = (network: NetworkId) =>
-  NetworkList[network].meta.defaultBalances
-
-// Get default chain for submitting transactions, by network
-export const getDefaultTxChain = (network: NetworkId) =>
-  NetworkList[network].meta.defaultTx
+// Get default staking chain for a network
+export const getStakingChain = (network: NetworkId) =>
+  NetworkList[network].meta.stakingChain
 
 // Get subscan balance chain id by network
 export const getSubscanBalanceChainId = (network: NetworkId) =>

--- a/packages/dedot-api/src/start.ts
+++ b/packages/dedot-api/src/start.ts
@@ -1,7 +1,11 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { getHubChainId, getNetworkData, getSystemChainData } from 'consts/util'
+import {
+  getHubChainId,
+  getRelayChainData,
+  getSystemChainData,
+} from 'consts/util'
 import { DedotClient, WsProvider } from 'dedot'
 import { setMultiApiStatus } from 'global-bus'
 import type { NetworkConfig, NetworkId, SystemChainId } from 'types'
@@ -21,7 +25,7 @@ export const getDefaultService = async <T extends NetworkId>(
   const peopleChainId: SystemChainId = `people-${network}`
   const hubChainId: SystemChainId = getHubChainId(network)
 
-  const relayData = getNetworkData(network)
+  const relayData = getRelayChainData(network)
   const peopleData = getSystemChainData(`people-${network}`)
   const hubData = getSystemChainData(hubChainId)
 

--- a/packages/dedot-api/src/subscribe/relayMetrics.ts
+++ b/packages/dedot-api/src/subscribe/relayMetrics.ts
@@ -21,10 +21,6 @@ export class RelayMetricsQuery<T extends RelayChain> {
     this.#unsub = await this.api.queryMulti(
       [
         {
-          fn: this.api.query.balances.totalIssuance,
-          args: [],
-        },
-        {
           fn: this.api.query.auctions.auctionCounter,
           args: [],
         },
@@ -33,9 +29,8 @@ export class RelayMetricsQuery<T extends RelayChain> {
           args: [],
         },
       ],
-      ([totalIssuance, auctionCounter, earliestStoredSession]) => {
+      ([auctionCounter, earliestStoredSession]) => {
         this.relayMetrics = {
-          totalIssuance,
           auctionCounter,
           earliestStoredSession,
         }

--- a/packages/dedot-api/src/subscribe/stakingMetrics.ts
+++ b/packages/dedot-api/src/subscribe/stakingMetrics.ts
@@ -24,6 +24,10 @@ export class StakingMetricsQuery<T extends StakingChain> {
     this.#unsub = await this.api.queryMulti(
       [
         {
+          fn: this.api.query.balances.totalIssuance,
+          args: [],
+        },
+        {
           fn: this.api.query.fastUnstake.erasToCheckPerBlock,
           args: [],
         },
@@ -65,6 +69,7 @@ export class StakingMetricsQuery<T extends StakingChain> {
         },
       ],
       ([
+        totalIssuance,
         erasToCheckPerBlock,
         minimumActiveStake,
         counterForValidators,
@@ -77,6 +82,7 @@ export class StakingMetricsQuery<T extends StakingChain> {
         counterForNominators,
       ]) => {
         this.stakingMetrics = {
+          totalIssuance,
           erasToCheckPerBlock,
           minimumActiveStake,
           counterForValidators,

--- a/packages/dedot-api/src/types/index.ts
+++ b/packages/dedot-api/src/types/index.ts
@@ -38,7 +38,7 @@ export type AssetHubChain =
   | WestendAssetHubApi
 
 // Chains that are used for staking and nomination pools
-export type StakingChain = PolkadotApi | KusamaApi | WestendApi
+export type StakingChain = PolkadotApi | KusamaApi | WestendAssetHubApi
 
 // Mapping of service types for each network
 export interface ServiceType {

--- a/packages/global-bus/src/relayMetrics/default.ts
+++ b/packages/global-bus/src/relayMetrics/default.ts
@@ -4,7 +4,6 @@
 import type { RelayMetrics } from 'types'
 
 export const defaultRelayMetrics: RelayMetrics = {
-  totalIssuance: 0n,
   auctionCounter: 0,
   earliestStoredSession: 0,
 }

--- a/packages/global-bus/src/stakingMetrics/default.ts
+++ b/packages/global-bus/src/stakingMetrics/default.ts
@@ -4,6 +4,7 @@
 import type { StakingMetrics } from 'types'
 
 export const defaultStakingMetrics: StakingMetrics = {
+  totalIssuance: 0n,
   erasToCheckPerBlock: 0,
   minimumActiveStake: 0n,
   counterForValidators: 0,

--- a/packages/types/src/networks.ts
+++ b/packages/types/src/networks.ts
@@ -108,6 +108,10 @@ export interface Network {
   units: number
   ss58: number
   defaultFeeReserve: bigint
+  meta: {
+    defaultBalances: ChainId
+    defaultTx: ChainId
+  }
 }
 
 export interface SystemChain {

--- a/packages/types/src/networks.ts
+++ b/packages/types/src/networks.ts
@@ -111,6 +111,7 @@ export interface Network {
   meta: {
     defaultBalances: ChainId
     defaultTx: ChainId
+    subscanBalanceChainId: string
   }
 }
 

--- a/packages/types/src/networks.ts
+++ b/packages/types/src/networks.ts
@@ -109,8 +109,7 @@ export interface Network {
   ss58: number
   defaultFeeReserve: bigint
   meta: {
-    defaultBalances: ChainId
-    defaultTx: ChainId
+    stakingChain: ChainId
     subscanBalanceChainId: string
   }
 }

--- a/packages/types/src/networks.ts
+++ b/packages/types/src/networks.ts
@@ -60,7 +60,6 @@ export interface ChainConsts {
 }
 
 export interface RelayMetrics {
-  totalIssuance: bigint
   auctionCounter: number
   earliestStoredSession: number
 }
@@ -79,6 +78,7 @@ export interface PoolsConfig {
 }
 
 export interface StakingMetrics {
+  totalIssuance: bigint
   erasToCheckPerBlock: number
   minimumActiveStake: bigint
   counterForValidators: number

--- a/packages/types/src/networks.ts
+++ b/packages/types/src/networks.ts
@@ -120,6 +120,7 @@ export interface SystemChain {
   ss58: number
   units: number
   unit: string
+  defaultFeeReserve: bigint
   endpoints: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     lightClient: () => Promise<any>


### PR DESCRIPTION
Migrates Westend from the relay chain to its asset hub chain.

- [x] Migrates `dedot-api` Westend service to use the correct chains (relay to hub)
- [x] Adds a utility for components to fetch the staking chain based on a network
- [x] Adds default fee reserve to system chains
