### PR TITLE
feat(refactor): Optimise tsconfigs

### DIFF
--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.react.json",
   "compilerOptions": {
     "baseUrl": "src",
     "outDir": "build",

--- a/packages/assets/tsconfig.json
+++ b/packages/assets/tsconfig.json
@@ -1,8 +1,4 @@
 {
-  "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.base.json",
   "include": ["src"]
 }

--- a/packages/dedot-api/tsconfig.json
+++ b/packages/dedot-api/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.react.json",
   "include": ["src"]
 }

--- a/packages/global-bus/tsconfig.json
+++ b/packages/global-bus/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.react.json",
   "include": ["src"]
 }

--- a/packages/locales/tsconfig.json
+++ b/packages/locales/tsconfig.json
@@ -1,20 +1,6 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.react.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "noEmit": true,
     "types": ["vite/client"]
   },
   "include": ["src"]

--- a/packages/plugin-staking-api/tsconfig.json
+++ b/packages/plugin-staking-api/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.react.json",
   "include": ["src"]
 }

--- a/packages/rpc-config/tsconfig.json
+++ b/packages/rpc-config/tsconfig.json
@@ -1,20 +1,6 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.react.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "noEmit": true,
     "types": ["node"]
   },
   "include": ["src", "../../env.d.ts"]

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,19 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.react.json",
   "include": ["src"]
 }

--- a/packages/ui-buttons/tsconfig.json
+++ b/packages/ui-buttons/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.react.json",
   "include": ["src", "../../env.d.ts"]
 }

--- a/packages/ui-core/tsconfig.json
+++ b/packages/ui-core/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.react.json",
   "include": ["src", "../../env.d.ts"]
 }

--- a/packages/ui-graphs/tsconfig.json
+++ b/packages/ui-graphs/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.react.json",
   "include": ["src", "../../env.d.ts"]
 }

--- a/packages/ui-identity/tsconfig.json
+++ b/packages/ui-identity/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.react.json",
   "include": ["src", "../../env.d.ts"]
 }

--- a/packages/ui-overlay/tsconfig.json
+++ b/packages/ui-overlay/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.react.json",
   "include": ["src", "../../env.d.ts"]
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,19 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
-    "allowJs": false,
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.react.json",
   "include": ["src"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../../tsconfig.react.json",
   "compilerOptions": {
     "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
-    "skipLibCheck": true,
     "moduleResolution": "Bundler",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "allowImportingTsExtensions": true,
     "allowJs": false,
@@ -14,7 +12,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "types": ["vite/client"]
-  },
-  "include": ["src"]
+    "useDefineForClassFields": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "noUnusedLocals": true
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,5 @@
 {
-  "compilerOptions": {
-    "rootDir": ".",
-    "declaration": true,
-    "declarationMap": false,
-    "noEmitOnError": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "strictPropertyInitialization": false,
-    "noUnusedLocals": true
-  },
+  "extends": "./tsconfig.base.json",
   "include": ["./packages/**/*", "**/*.d.ts"],
   "exclude": ["**/*/node_modules", "**/*/dist", "**/*/lottie"]
 }

--- a/tsconfig.react.json
+++ b/tsconfig.react.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
Minimising tsconfig.json configs by creating reusable tsconfig files.

- Created [tsconfig.base.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) (core options) and [tsconfig.react.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) (adds JSX support) in the root.
- All package configs now extend one of these, keeping only package-specific overrides (like types, include, or baseUrl).
- The root [tsconfig.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) is now minimal and extends the base config.

This structure will make future changes to TypeScript settings much easier and more consistent across your monorepo.