### PR TITLE
chore: active validators optimisation

### DIFF
--- a/packages/app/src/contexts/EraStakers/defaults.ts
+++ b/packages/app/src/contexts/EraStakers/defaults.ts
@@ -5,7 +5,6 @@ import type { EraStakers } from './types'
 
 export const defaultEraStakers: EraStakers = {
   activeAccountOwnStake: [],
-  activeValidators: 0,
   stakers: [],
   totalActiveNominators: 0,
 }

--- a/packages/app/src/contexts/EraStakers/index.tsx
+++ b/packages/app/src/contexts/EraStakers/index.tsx
@@ -31,6 +31,9 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
   const [eraStakers, setEraStakers] = useState<EraStakers>(defaultEraStakers)
   const eraStakersRef = useRef(eraStakers)
 
+  // Store active validators
+  const [activeValidators, setActiveValidators] = useState<number>(0)
+
   worker.onmessage = (message: MessageEvent) => {
     if (message) {
       const { data }: { data: ProcessExposuresResponse } = message
@@ -45,13 +48,8 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
         return
       }
 
-      const {
-        stakers,
-        totalActiveNominators,
-        activeValidators,
-        activeAccountOwnStake,
-        who,
-      } = data
+      const { stakers, totalActiveNominators, activeAccountOwnStake, who } =
+        data
 
       // Check if account hasn't changed since worker started
       if (activeAddress === who) {
@@ -63,7 +61,6 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
             ...eraStakersRef.current,
             stakers,
             totalActiveNominators,
-            activeValidators,
             activeAccountOwnStake,
           },
           setEraStakers,
@@ -106,7 +103,10 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
       return
     }
     setSyncing('era-stakers')
+
     const exposures = await fetchEraStakers(activeEra.index.toString())
+
+    setActiveValidators(exposures.length)
 
     // Worker to calculate stats
     worker.postMessage({
@@ -189,6 +189,7 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
     <EraStakersContext.Provider
       value={{
         eraStakers,
+        activeValidators,
         fetchEraStakers,
         getPagedErasStakers,
       }}

--- a/packages/app/src/contexts/EraStakers/index.tsx
+++ b/packages/app/src/contexts/EraStakers/index.tsx
@@ -174,6 +174,7 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
 
   useEffectIgnoreInitial(() => {
     if (getApiStatus(network) === 'connecting') {
+      setActiveValidators(0)
       setStateWithRef(defaultEraStakers, setEraStakers, eraStakersRef)
     }
   }, [getApiStatus(network)])

--- a/packages/app/src/contexts/EraStakers/types.ts
+++ b/packages/app/src/contexts/EraStakers/types.ts
@@ -3,6 +3,7 @@
 
 export interface EraStakersContextInterface {
   eraStakers: EraStakers
+  activeValidators: number
   fetchEraStakers: (era: string) => Promise<Exposure[]>
   getPagedErasStakers: (e: string) => Promise<Exposure[]>
 }
@@ -13,7 +14,6 @@ export interface ActiveAccountOwnStake {
 }
 export interface EraStakers {
   activeAccountOwnStake: ActiveAccountOwnStake[]
-  activeValidators: number
   stakers: Staker[]
   totalActiveNominators: number
 }

--- a/packages/app/src/pages/Validators/Stats/ActiveValidators.tsx
+++ b/packages/app/src/pages/Validators/Stats/ActiveValidators.tsx
@@ -10,9 +10,7 @@ import { percentageOf } from 'ui-graphs/util'
 
 export const ActiveValidators = () => {
   const { t } = useTranslation('pages')
-  const {
-    eraStakers: { activeValidators },
-  } = useEraStakers()
+  const { activeValidators } = useEraStakers()
   const { validatorCount } = useApi().stakingMetrics
 
   // active validators as percent. Avoiding dividing by zero.

--- a/packages/app/src/workers/stakers.ts
+++ b/packages/app/src/workers/stakers.ts
@@ -27,13 +27,10 @@ const processExposures = (data: ProcessExposuresArgs) => {
   const { task, networkName, era, units, exposures, activeAccount } = data
 
   const stakers: Staker[] = []
-  let activeValidators = 0
   const activeAccountOwnStake: ActiveAccountStaker[] = []
   const nominators: ExposureOther[] = []
 
   exposures.forEach(({ keys, val }) => {
-    activeValidators++
-
     const address = keys[1]
     let others =
       val.others.map((o) => ({
@@ -93,7 +90,6 @@ const processExposures = (data: ProcessExposuresArgs) => {
     stakers,
     totalActiveNominators: nominators.length,
     activeAccountOwnStake,
-    activeValidators,
     task,
     who: activeAccount,
   }

--- a/packages/app/src/workers/types.ts
+++ b/packages/app/src/workers/types.ts
@@ -21,6 +21,5 @@ export interface ProcessExposuresResponse {
   stakers: Staker[]
   totalActiveNominators: number
   activeAccountOwnStake: ActiveAccountStaker[]
-  activeValidators: number
   who: MaybeAddress
 }


### PR DESCRIPTION
Amends active validator logic by not counting exposures through the worker, but simply to refer to exposure length. This old logic was an artefact of when active validators had to be determined via the worker.