### PR TITLE
fix: Enable Fast Unstake for legacy nominators below active thresholds

### DIFF
--- a/packages/app/src/hooks/useUnstaking/index.tsx
+++ b/packages/app/src/hooks/useUnstaking/index.tsx
@@ -1,8 +1,10 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import BigNumber from 'bignumber.js'
 import { getStakingChainData } from 'consts/util/chains'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
+import { useApi } from 'contexts/Api'
 import { useFastUnstake } from 'contexts/FastUnstake'
 import { useNetwork } from 'contexts/Network'
 import { useStaking } from 'contexts/Staking'
@@ -15,6 +17,9 @@ export const useUnstaking = () => {
   const { network } = useNetwork()
   const { isNominator } = useStaking()
   const { activeAddress } = useActiveAccounts()
+  const {
+    stakingMetrics: { minNominatorBond, minimumActiveStake },
+  } = useApi()
   const { getNominationStatus } = useNominationStatus()
   const { head, queueDeposit, fastUnstakeStatus, exposed } = useFastUnstake()
   const {
@@ -25,6 +30,14 @@ export const useUnstaking = () => {
   const { ss58 } = getStakingChainData(network)
   const { nominees } = getNominationStatus(activeAddress, 'nominator')
 
+  // Calculate if this is a legacy nominator
+  const minToEarnRewards = BigNumber.max(minNominatorBond, minimumActiveStake)
+  const isLegacyNominator =
+    active > 0n &&
+    new BigNumber(active.toString()).isLessThan(
+      new BigNumber(minToEarnRewards.toString())
+    )
+
   // Determine if user is fast unstaking
   const inHead =
     head?.stashes.find((s) => s[0].address(ss58) === activeAddress) ?? undefined
@@ -32,8 +45,12 @@ export const useUnstaking = () => {
 
   const registered = inHead || inQueue
 
-  // Fetermine unstake button
+  // Determine unstake button text
   const getFastUnstakeText = () => {
+    // Special handling for legacy nominators
+    if (isLegacyNominator && fastUnstakeStatus?.status === 'EXPOSED') {
+      return t('fastUnstake') // Show as available
+    }
     if (exposed && fastUnstakeStatus?.lastExposed) {
       return t('fastUnstakeExposed', {
         count: Number(fastUnstakeStatus.lastExposed),
@@ -49,5 +66,6 @@ export const useUnstaking = () => {
     getFastUnstakeText,
     isUnstaking: isNominator && !nominees.active.length && active === 0n,
     isFastUnstaking: !!registered,
+    isLegacyNominator, // Export this for other components
   }
 }


### PR DESCRIPTION
- Add logic to detect legacy nominators with active stake below minimum bond
- Override 'EXPOSED' status for eligible legacy nominators
- Allow fast unstake access for sub-threshold legacy stakes