### PR TITLE
feat: add missing nominatingAndInPool translations for dual staking

### DIFF
--- a/packages/locales/src/resources/en/modals.json
+++ b/packages/locales/src/resources/en/modals.json
@@ -200,6 +200,7 @@
     "nominateQuickSubtitle": "Stake immediately with an optimised setup",
     "nominateQuickTitle": "One-Click Setup",
     "nominating": "Nominating",
+    "nominatingAndInPool": "Nominating & In Pool",
     "nomination_one": "{{count}} Nomination",
     "nomination_other": "{{count}} Nominations",
     "nominator": "Nominator",

--- a/packages/locales/src/resources/es/modals.json
+++ b/packages/locales/src/resources/es/modals.json
@@ -200,6 +200,7 @@
     "nominateQuickSubtitle": "Apueste inmediatamente con una configuración optimizada",
     "nominateQuickTitle": "Configuración con un solo clic",
     "nominating": "Nominando",
+    "nominatingAndInPool": "Nominando y en Pool",
     "nomination_one": "{{count}} Nominación",
     "nomination_other": "{{count}} Nominaciones",
     "nominator": "Nominador",

--- a/packages/locales/src/resources/zh/modals.json
+++ b/packages/locales/src/resources/zh/modals.json
@@ -190,6 +190,7 @@
     "nominateQuickSubtitle": "使用优化设置立即进行质押",
     "nominateQuickTitle": "一键设置",
     "nominating": "提名中",
+    "nominatingAndInPool": "提名中 & 提名池中",
     "nomination": "{{count}} 个提名",
     "nominator": "提名人",
     "nominatorStake": "提名人抵押",


### PR DESCRIPTION
- Add "nominatingAndInPool" key to EN, ES, and ZH modals.json files
- Fixes display of raw key instead of translated text in Accounts modal
- Covers edge case where accounts are both nominating validators and in pools