### PR TITLE
fix: allow unbond/unstake for any user with bonded funds, not just active nominators

### DIFF
--- a/packages/app/src/pages/Nominate/Active/ManageBond.tsx
+++ b/packages/app/src/pages/Nominate/Active/ManageBond.tsx
@@ -66,10 +66,7 @@ export const ManageBond = () => {
     !exposed
 
   // Whether unstake buttons should be disabled
-  const unstakeDisabled = !isBonding || (syncing && !isBonding)
-
-  // Whether unstake buttons should be hidden
-  const unstakeHidden = unstakeDisabled || isReadOnlyAccount(activeAddress)
+  const unstakeDisabled = !isReady || !isBonding || (syncing && !isBonding)
 
   // Whether the bond buttons should be disabled
   const bondDisabled =
@@ -77,12 +74,12 @@ export const ManageBond = () => {
 
   // The available unstake buttons to display. If fast unstaking is available, it will show the fast
   // unstake button. Regular unstake button will always be available if the user can unbond
-  const unstakeButtons = (
+  const unstakeButtons = !isReadOnlyAccount(activeAddress) ? (
     <>
       {fastUnstakeEligible && (
         <ButtonPrimary
           size="md"
-          disabled={isReadOnlyAccount(activeAddress)}
+          disabled={unstakeDisabled}
           text={getFastUnstakeText()}
           iconLeft={faBolt}
           onClick={() => {
@@ -94,16 +91,11 @@ export const ManageBond = () => {
         size="md"
         text={t('unstake')}
         iconLeft={faSignOutAlt}
-        disabled={
-          !isReady ||
-          isReadOnlyAccount(activeAddress) ||
-          !activeAddress ||
-          !isBonding
-        }
+        disabled={unstakeDisabled}
         onClick={() => openModal({ key: 'Unstake', size: 'sm' })}
       />
     </>
-  )
+  ) : null
 
   return (
     <>
@@ -154,7 +146,7 @@ export const ManageBond = () => {
               text=""
             />
           </MultiButton.Container>
-          {!unstakeHidden && unstakeButtons}
+          {unstakeButtons}
         </ButtonRow>
       </CardHeader>
       <BondedChart

--- a/packages/app/src/pages/Nominate/Active/ManageBond.tsx
+++ b/packages/app/src/pages/Nominate/Active/ManageBond.tsx
@@ -63,33 +63,28 @@ export const ManageBond = () => {
   const hasNominatorFunds = active > 0n
   const canUnbond = hasNominatorFunds || isBonding
 
-  // Determine whether to display fast unstake button.
-  const showFastUnstake =
+  // Determine whether fast unstake is available
+  const fastUnstakeEligible =
     erasToCheckPerBlock > 0 &&
     !nominationStatus.nominees.active.length &&
     fastUnstakeStatus !== null &&
     !exposed
 
-  // Only show the regular unstake button if not read-only
-  const regularUnstakeButton = (
-    <ButtonPrimary
-      size="md"
-      text={t('unstake')}
-      iconLeft={faSignOutAlt}
-      disabled={
-        !isReady ||
-        isReadOnlyAccount(activeAddress) ||
-        !activeAddress ||
-        !canUnbond
-      }
-      onClick={() => openModal({ key: 'Unstake', size: 'sm' })}
-    />
-  )
+  // Whether unstake buttons should be disabled
+  const unstakeDisabled = !canUnbond || (syncing && !hasNominatorFunds)
 
-  // Show both buttons if both are available, but both are disabled for read-only
+  // Whether unstake buttons should be hidden
+  const unstakeHidden = unstakeDisabled || isReadOnlyAccount(activeAddress)
+
+  // Whether the bond buttons should be disabled
+  const bondDisabled =
+    unstakeDisabled || isFastUnstaking || isReadOnlyAccount(activeAddress)
+
+  // The available unstake buttons to display. If fast unstaking is available, it will show the fast
+  // unstake button. Regular unstake button will always be available if the user can unbond
   const unstakeButtons = (
     <>
-      {showFastUnstake && (
+      {fastUnstakeEligible && (
         <ButtonPrimary
           size="md"
           disabled={isReadOnlyAccount(activeAddress)}
@@ -100,16 +95,20 @@ export const ManageBond = () => {
           }}
         />
       )}
-      {regularUnstakeButton}
+      <ButtonPrimary
+        size="md"
+        text={t('unstake')}
+        iconLeft={faSignOutAlt}
+        disabled={
+          !isReady ||
+          isReadOnlyAccount(activeAddress) ||
+          !activeAddress ||
+          !canUnbond
+        }
+        onClick={() => openModal({ key: 'Unstake', size: 'sm' })}
+      />
     </>
   )
-
-  const unstakeDisabled =
-    !canUnbond ||
-    (syncing && !hasNominatorFunds) ||
-    isReadOnlyAccount(activeAddress)
-
-  const bondDisabled = unstakeDisabled || isFastUnstaking
 
   return (
     <>
@@ -160,7 +159,7 @@ export const ManageBond = () => {
               text=""
             />
           </MultiButton.Container>
-          {!unstakeDisabled && unstakeButtons}
+          {!unstakeHidden && unstakeButtons}
         </ButtonRow>
       </CardHeader>
       <BondedChart

--- a/packages/app/src/pages/Nominate/Active/ManageBond.tsx
+++ b/packages/app/src/pages/Nominate/Active/ManageBond.tsx
@@ -72,8 +72,9 @@ export const ManageBond = () => {
   const bondDisabled =
     unstakeDisabled || isFastUnstaking || isReadOnlyAccount(activeAddress)
 
-  // The available unstake buttons to display. If fast unstaking is available, it will show the fast
-  // unstake button. Regular unstake button will always be available if the user can unbond
+  // The available unstake buttons to display. If fast unstaking is available the fast unstake
+  // button will be displayed. Regular unstake button is always showing - unless the account is
+  // read-only.
   const unstakeButtons = !isReadOnlyAccount(activeAddress) ? (
     <>
       {fastUnstakeEligible && (

--- a/packages/app/src/pages/Nominate/Active/ManageBond.tsx
+++ b/packages/app/src/pages/Nominate/Active/ManageBond.tsx
@@ -58,11 +58,6 @@ export const ManageBond = () => {
   const { totalUnlocking, totalUnlocked } = balances.nominator
   const nominationStatus = getNominationStatus(activeAddress, 'nominator')
 
-  // Check for actual bonded funds directly from ledger to handle dual staking scenarios
-  // where isBonding might be false due to subscription issues
-  const hasNominatorFunds = active > 0n
-  const canUnbond = hasNominatorFunds || isBonding
-
   // Determine whether fast unstake is available
   const fastUnstakeEligible =
     erasToCheckPerBlock > 0 &&
@@ -71,7 +66,7 @@ export const ManageBond = () => {
     !exposed
 
   // Whether unstake buttons should be disabled
-  const unstakeDisabled = !canUnbond || (syncing && !hasNominatorFunds)
+  const unstakeDisabled = !isBonding || (syncing && !isBonding)
 
   // Whether unstake buttons should be hidden
   const unstakeHidden = unstakeDisabled || isReadOnlyAccount(activeAddress)
@@ -103,7 +98,7 @@ export const ManageBond = () => {
           !isReady ||
           isReadOnlyAccount(activeAddress) ||
           !activeAddress ||
-          !canUnbond
+          !isBonding
         }
         onClick={() => openModal({ key: 'Unstake', size: 'sm' })}
       />


### PR DESCRIPTION
Fixed logic in ManageBond.tsx that previously required users to be actively nominating to access unbond/unstake actions.

Now, any user with bonded nominator funds can unbond, regardless of whether they are currently nominating or have stopped nominating.

This resolves issues for users who:
  - Have stopped nominating but still have bonded funds.
  - Are in a pool but have leftover nominator funds (dual staking cleanup).