### PR TITLE
feat(fix): treat bonding only as nominating

### DIFF
--- a/packages/app/src/canvas/Pool/Overview/index.tsx
+++ b/packages/app/src/canvas/Pool/Overview/index.tsx
@@ -15,13 +15,13 @@ import { Stats } from './Stats'
 
 export const Overview = (props: OverviewSectionProps) => {
   const { inPool } = useActivePool()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { activeAddress } = useActiveAccounts()
   const {
     bondedPool: { state },
   } = props
   const showJoinForm =
-    activeAddress !== null && state === 'Open' && !inPool && !isNominator
+    activeAddress !== null && state === 'Open' && !inPool && !isBonding
 
   return (
     <Interface

--- a/packages/app/src/library/Headers/Popovers/NotificationsPopover/index.tsx
+++ b/packages/app/src/library/Headers/Popovers/NotificationsPopover/index.tsx
@@ -19,13 +19,13 @@ export const NotificationsPopover = ({
   setOpen: Dispatch<SetStateAction<boolean>>
 }) => {
   const { t } = useTranslation('app')
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { getPoolMembership } = useBalances()
   const { activeAddress } = useActiveAccounts()
   const { inviteConfig, dismissInvite } = useInvites()
 
   const { membership } = getPoolMembership(activeAddress)
-  const alreadyStaking = membership || isNominator
+  const alreadyStaking = membership || isBonding
 
   // NOTE: We assume a valid pool invite is active
   const popoverRef = useRef<HTMLDivElement>(null)

--- a/packages/app/src/library/Nominations/index.tsx
+++ b/packages/app/src/library/Nominations/index.tsx
@@ -39,7 +39,7 @@ export const Nominations = ({
     modal: { openModal },
     canvas: { openCanvas },
   } = useOverlay()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { syncing } = useSyncing(['era-stakers'])
   const { getNominations } = useBalances()
   const { isFastUnstaking } = useUnstaking()
@@ -75,7 +75,7 @@ export const Nominations = ({
 
   // Determine whether buttons are disabled.
   const btnsDisabled =
-    (!isPool && !isNominator) ||
+    (!isPool && !isBonding) ||
     (!isPool && syncing) ||
     isReadOnlyAccount(activeAddress) ||
     poolDestroying ||

--- a/packages/app/src/library/SideMenu/Main.tsx
+++ b/packages/app/src/library/SideMenu/Main.tsx
@@ -24,7 +24,7 @@ export const Main = () => {
   const { network } = useNetwork()
   const { pathname } = useLocation()
   const { inPool } = useActivePool()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { formatWithPrefs } = useValidators()
   const { activeAddress } = useActiveAccounts()
   const { sideMenuMinimised, advancedMode } = useUi()
@@ -48,13 +48,13 @@ export const Main = () => {
         }
       }
       if (uri === `${import.meta.env.BASE_URL}nominate`) {
-        if (isNominator) {
+        if (isBonding) {
           pages[i].bullet = 'accent'
           return true
         }
         if (
           (!syncing && controllerUnmigrated) ||
-          (isNominator && fullCommissionNominees.length > 0)
+          (isBonding && fullCommissionNominees.length > 0)
         ) {
           pages[i].bullet = 'warning'
           return true

--- a/packages/app/src/library/StatusLabel/index.tsx
+++ b/packages/app/src/library/StatusLabel/index.tsx
@@ -24,11 +24,11 @@ export const StatusLabel = ({
   const { syncing } = useSyncing()
   const { plugins } = usePlugins()
   const { inPool } = useActivePool()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
 
   // syncing or not staking
   if (status === 'sync_or_setup') {
-    if (syncing || isNominator || inPool) {
+    if (syncing || isBonding || inPool) {
       return null
     }
   }

--- a/packages/app/src/modals/SetController/index.tsx
+++ b/packages/app/src/modals/SetController/index.tsx
@@ -17,7 +17,7 @@ import { Close, useOverlay } from 'ui-overlay'
 export const SetController = () => {
   const { t } = useTranslation('app')
   const { serviceApi } = useApi()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { getStakingLedger } = useBalances()
   const { activeAddress } = useActiveAccounts()
   const { setModalStatus } = useOverlay().modal
@@ -26,7 +26,7 @@ export const SetController = () => {
   const { controllerUnmigrated } = getStakingLedger(activeAddress)
 
   const canDeprecateController =
-    isNominator &&
+    isBonding &&
     !syncing &&
     accountSynced(activeAddress) &&
     controllerUnmigrated &&

--- a/packages/app/src/pages/Nominate/Active/CommissionPrompt.tsx
+++ b/packages/app/src/pages/Nominate/Active/CommissionPrompt.tsx
@@ -20,7 +20,7 @@ import { useOverlay } from 'ui-overlay'
 
 export const CommissionPrompt = () => {
   const { t } = useTranslation('pages')
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { getNominations } = useBalances()
   const { openCanvas } = useOverlay().canvas
   const { getThemeValue } = useThemeValues()
@@ -33,7 +33,7 @@ export const CommissionPrompt = () => {
     (nominee) => nominee.prefs.commission === 100
   )
 
-  if (!fullCommissionNominees.length || !isNominator || syncing) {
+  if (!fullCommissionNominees.length || !isBonding || syncing) {
     return null
   }
 

--- a/packages/app/src/pages/Nominate/Active/Status/PayoutDestinationStatus.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/PayoutDestinationStatus.tsx
@@ -16,7 +16,7 @@ import { useOverlay } from 'ui-overlay'
 export const PayoutDestinationStatus = () => {
   const { t } = useTranslation('pages')
   const { syncing } = useSyncing()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { openModal } = useOverlay().modal
   const { getStakingLedger } = useBalances()
   const { isFastUnstaking } = useUnstaking()
@@ -28,7 +28,7 @@ export const PayoutDestinationStatus = () => {
 
   // Get payee status text to display.
   const getPayeeStatus = () => {
-    if (!isNominator) {
+    if (!isBonding) {
       return t('notAssigned')
     }
     const status = getPayeeItems(true).find(
@@ -42,7 +42,7 @@ export const PayoutDestinationStatus = () => {
   }
 
   // Get the payee destination icon to display, falling back to wallet icon.
-  const payeeIcon = !isNominator
+  const payeeIcon = !isBonding
     ? undefined
     : getPayeeItems(true).find(({ value }) => value === payee?.destination)
         ?.icon || faWallet
@@ -54,12 +54,12 @@ export const PayoutDestinationStatus = () => {
       icon={payeeIcon}
       stat={getPayeeStatus()}
       buttons={
-        isNominator && !isReadOnlyAccount(activeAddress)
+        isBonding && !isReadOnlyAccount(activeAddress)
           ? [
               {
                 title: t('update'),
                 icon: faGear,
-                disabled: syncing || !isNominator || isFastUnstaking,
+                disabled: syncing || !isBonding || isFastUnstaking,
                 onClick: () => openModal({ key: 'UpdatePayee', size: 'sm' }),
               },
             ]

--- a/packages/app/src/pages/Nominate/Active/Status/index.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/index.tsx
@@ -15,7 +15,7 @@ import { UnclaimedPayoutsStatus } from './UnclaimedPayoutsStatus'
 
 export const Status = ({ height }: { height: number }) => {
   const { syncing } = useSyncing()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { pluginEnabled } = usePlugins()
   const { activeAddress } = useActiveAccounts()
   const { isReadOnlyAccount } = useImportedAccounts()
@@ -23,16 +23,16 @@ export const Status = ({ height }: { height: number }) => {
   return (
     <CardWrapper
       height={height}
-      className={!syncing && !isNominator ? 'prompt' : undefined}
+      className={!syncing && !isBonding ? 'prompt' : undefined}
     >
       <NominationStatus />
       <Separator />
       <UnclaimedPayoutsStatus
-        dimmed={!isNominator || !pluginEnabled('staking_api')}
+        dimmed={!isBonding || !pluginEnabled('staking_api')}
       />
 
       {!syncing ? (
-        isNominator ? (
+        isBonding ? (
           <>
             <Separator />
             <PayoutDestinationStatus />

--- a/packages/app/src/pages/Nominate/Active/UnstakePrompts.tsx
+++ b/packages/app/src/pages/Nominate/Active/UnstakePrompts.tsx
@@ -20,7 +20,7 @@ export const UnstakePrompts = () => {
   const { t } = useTranslation('pages')
   const { syncing } = useSyncing()
   const { network } = useNetwork()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { openModal } = useOverlay().modal
   const { getThemeValue } = useThemeValues()
   const { activeAddress } = useActiveAccounts()
@@ -36,7 +36,7 @@ export const UnstakePrompts = () => {
     isUnstaking && active === 0n && totalUnlocking === 0n && totalUnlocked > 0n
 
   return (
-    isNominator &&
+    isBonding &&
     (isUnstaking || isFastUnstaking) &&
     !syncing && (
       <Page.Row>

--- a/packages/app/src/pages/Nominate/Active/index.tsx
+++ b/packages/app/src/pages/Nominate/Active/index.tsx
@@ -29,12 +29,12 @@ export const Active = () => {
   const { t } = useTranslation()
   const { openHelp } = useHelp()
   const { syncing } = useSyncing()
+  const { isBonding } = useStaking()
   const { getNominations } = useBalances()
   const { openCanvas } = useOverlay().canvas
   const { isFastUnstaking } = useUnstaking()
   const { formatWithPrefs } = useValidators()
   const { activeAddress } = useActiveAccounts()
-  const { isNominator, isBonding } = useStaking()
 
   const nominated = formatWithPrefs(getNominations(activeAddress))
   const ROW_HEIGHT = 220
@@ -63,7 +63,7 @@ export const Active = () => {
       {isBonding && (
         <Page.Row>
           <CardWrapper>
-            {nominated?.length || !isNominator || syncing ? (
+            {nominated?.length || syncing ? (
               <Nominations bondFor="nominator" nominator={activeAddress} />
             ) : (
               <>
@@ -81,7 +81,7 @@ export const Active = () => {
                       iconLeft={faChevronCircleRight}
                       iconTransform="grow-1"
                       text={`${t('nominate', { ns: 'pages' })}`}
-                      disabled={!isNominator || syncing || isFastUnstaking}
+                      disabled={syncing || isFastUnstaking}
                       onClick={() =>
                         openCanvas({
                           key: 'ManageNominations',

--- a/packages/app/src/pages/Overview/Payouts/index.tsx
+++ b/packages/app/src/pages/Overview/Payouts/index.tsx
@@ -32,12 +32,12 @@ export const Payouts = () => {
   const { containerRefs } = useUi()
   const { inPool } = useActivePool()
   const { currency } = useCurrency()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { pluginEnabled } = usePlugins()
 
   const { units } = getStakingChainData(network)
   const Token = getChainIcons(network).token
-  const staking = isNominator || inPool
+  const staking = isBonding || inPool
   const notStaking = !syncing && !staking
 
   const [lastReward, setLastReward] = useState<RewardResult>()
@@ -108,7 +108,7 @@ export const Payouts = () => {
         >
           {staking && pluginEnabled('staking_api') ? (
             <ActiveGraph
-              nominating={isNominator}
+              nominating={isBonding}
               inPool={inPool}
               lineMarginTop="3rem"
               setLastReward={setLastReward}

--- a/packages/app/src/pages/Overview/QuickActions/index.tsx
+++ b/packages/app/src/pages/Overview/QuickActions/index.tsx
@@ -17,11 +17,11 @@ import type { QuickActionGroup } from './types'
 export const QuickActions = ({ height }: { height: number }) => {
   const { t } = useTranslation('pages')
   const { inPool } = useActivePool()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { accountSynced } = useSyncing()
   const { activeAddress } = useActiveAccounts()
 
-  const isStaking = inPool || isNominator
+  const isStaking = inPool || isBonding
   const syncing = !accountSynced(activeAddress)
 
   let actionGroup: QuickActionGroup = 'staking'

--- a/packages/app/src/pages/Overview/StakeStatus/index.tsx
+++ b/packages/app/src/pages/Overview/StakeStatus/index.tsx
@@ -12,10 +12,10 @@ import { StatusWrapper } from './Wrappers'
 
 export const StakeStatus = ({ height }: { height: number }) => {
   const { inPool } = useActivePool()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
 
-  const notStaking = !inPool && !isNominator
-  const showNominate = notStaking || isNominator
+  const notStaking = !inPool && !isBonding
+  const showNominate = notStaking || isBonding
   const showMembership = notStaking || inPool
 
   return (

--- a/packages/app/src/pages/Overview/index.tsx
+++ b/packages/app/src/pages/Overview/index.tsx
@@ -25,7 +25,7 @@ import { SupplyStaked } from './Stats/SupplyStaked'
 export const Overview = () => {
   const { t } = useTranslation('pages')
   const { network } = useNetwork()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { pluginEnabled } = usePlugins()
   const { getStakingLedger } = useBalances()
   const { activeAddress } = useActiveAccounts()
@@ -48,7 +48,7 @@ export const Overview = () => {
         <SupplyStaked />
         <NextRewards />
       </Stat.Row>
-      {isNominator &&
+      {isBonding &&
         !syncing &&
         accountSynced(activeAddress) &&
         controllerUnmigrated &&

--- a/packages/app/src/pages/Pools/Status/MembershipStatus.tsx
+++ b/packages/app/src/pages/Pools/Status/MembershipStatus.tsx
@@ -22,7 +22,7 @@ export const MembershipStatus = ({
 }: MembershipStatusProps) => {
   const { t } = useTranslation('pages')
   const { isReady } = useApi()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { label } = useStatusButtons()
   const { openModal } = useOverlay().modal
   const { poolsMetaData } = useBondedPools()
@@ -83,7 +83,7 @@ export const MembershipStatus = ({
     <Stat
       label={t('poolMembership')}
       helpKey="Pool Membership"
-      stat={isNominator ? t('alreadyNominating') : t('notInPool')}
+      stat={isBonding ? t('alreadyNominating') : t('notInPool')}
       buttonType={buttonType}
     />
   )

--- a/packages/app/src/pages/Pools/Status/NewMember.tsx
+++ b/packages/app/src/pages/Pools/Status/NewMember.tsx
@@ -14,16 +14,16 @@ import { useStatusButtons } from './useStatusButtons'
 
 export const NewMember = ({ syncing }: NewMemberProps) => {
   const { t } = useTranslation()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { setActiveTab } = usePoolsTabs()
   const { openCanvas } = useOverlay().canvas
   const { getJoinDisabled, getCreateDisabled } = useStatusButtons()
 
   // Alias for create button disabled state
-  const createDisabled = getCreateDisabled() || isNominator
+  const createDisabled = getCreateDisabled() || isBonding
 
   // Disable opening the canvas if data is not ready.
-  const joinButtonDisabled = getJoinDisabled() || isNominator
+  const joinButtonDisabled = getJoinDisabled() || isBonding
 
   return (
     <CallToActionWrapper>

--- a/packages/app/src/pages/Rewards/Overview/RecentPayouts/index.tsx
+++ b/packages/app/src/pages/Rewards/Overview/RecentPayouts/index.tsx
@@ -29,7 +29,7 @@ export const RecentPayouts = ({
   const { syncing } = useSyncing()
   const { containerRefs } = useUi()
   const { inPool } = useActivePool()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { pluginEnabled } = usePlugins()
 
   const payoutsFromDate = getPayoutsFromDate(
@@ -40,7 +40,7 @@ export const RecentPayouts = ({
     payoutsList,
     locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat
   )
-  const staking = isNominator || inPool
+  const staking = isBonding || inPool
   const notStaking = !syncing && !staking
 
   const ref = useRef<HTMLDivElement>(null)
@@ -100,7 +100,7 @@ export const RecentPayouts = ({
         >
           {staking && pluginEnabled('staking_api') ? (
             <ActiveGraph
-              nominating={isNominator}
+              nominating={isBonding}
               inPool={inPool}
               payoutGraphData={payoutGraphData}
               loading={loading}

--- a/packages/app/src/pages/Rewards/Stats/RewardTrend.tsx
+++ b/packages/app/src/pages/Rewards/Stats/RewardTrend.tsx
@@ -23,7 +23,7 @@ export const RewardTrend = () => {
   const { t } = useTranslation('pages')
   const { network } = useNetwork()
   const { activeEra } = useApi()
-  const { isNominator } = useStaking()
+  const { isBonding } = useStaking()
   const { erasPerDay } = useErasPerDay()
   const { activeAddress } = useActiveAccounts()
 
@@ -48,7 +48,7 @@ export const RewardTrend = () => {
 
   useEffect(() => {
     setRewardTrend(null)
-    if (isNominator || membership) {
+    if (isBonding || membership) {
       getRewardTrend()
     }
   }, [
@@ -56,7 +56,7 @@ export const RewardTrend = () => {
     network,
     activeEra.index.toString(),
     membership,
-    isNominator,
+    isBonding,
   ])
 
   // Format the reward trend data


### PR DESCRIPTION
Treat's `isBonding` as the only requirement for nominating. Fixes an issue where users who were bonding but not nominating could use nominator features.