### PR TITLE
fix(balance): remove Kusama from account balance migration

### DIFF
--- a/packages/dedot-api/src/subscribe/accountBalance.ts
+++ b/packages/dedot-api/src/subscribe/accountBalance.ts
@@ -27,7 +27,7 @@ export class AccountBalanceQuery<T extends Chain> {
         // MIGRATION: Westend now factors staking amount into the free balance. Temporarily deduct
         // the active ledger from free balance for other relay chains
         let free: bigint = data.free
-        if (['polkadot', 'kusama'].includes(this.api.runtimeVersion.specName)) {
+        if (['polkadot'].includes(this.api.runtimeVersion.specName)) {
           const api = this.api as unknown as DedotClient<StakingChain>
           const bonded = await api.query.staking.bonded(this.address)
           if (bonded) {


### PR DESCRIPTION
Remove Kusama from the temporary migration that deducts active staking amounts from free balance. This migration was causing incorrect balance calculations where users had 0 KSM available for bonding despite having transferable funds.

Fixes balance display and bonding functionality on Kusama.