### PR TITLE
fix: remove polkadot from balance migration condition to display correct free balance

### DIFF
--- a/packages/dedot-api/src/subscribe/accountBalance.ts
+++ b/packages/dedot-api/src/subscribe/accountBalance.ts
@@ -1,12 +1,11 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { maxBigInt } from '@w3ux/utils'
 import type { DedotClient } from 'dedot'
 import type { Unsub } from 'dedot/types'
 import { removeAccountBalance, setAccountBalance } from 'global-bus'
 import type { AccountBalance, ChainId } from 'types'
-import type { Chain, StakingChain } from '../types'
+import type { Chain } from '../types'
 
 export class AccountBalanceQuery<T extends Chain> {
   #unsub: Unsub | undefined = undefined
@@ -26,16 +25,17 @@ export class AccountBalanceQuery<T extends Chain> {
       async ({ nonce, data }) => {
         // MIGRATION: Westend now factors staking amount into the free balance. Temporarily deduct
         // the active ledger from free balance for other relay chains
-        let free: bigint = data.free
-        if (['polkadot'].includes(this.api.runtimeVersion.specName)) {
-          const api = this.api as unknown as DedotClient<StakingChain>
-          const bonded = await api.query.staking.bonded(this.address)
-          if (bonded) {
-            const ledger = await api.query.staking.ledger(bonded)
-            const active = ledger?.active || 0n
-            free = maxBigInt(data.free - active, 0n)
-          }
-        }
+        const free: bigint = data.free
+        // NOTE: Migration logic commented out as all chains now handle free balance correctly
+        // if (['polkadot'].includes(this.api.runtimeVersion.specName)) {
+        //   const api = this.api as unknown as DedotClient<StakingChain>
+        //   const bonded = await api.query.staking.bonded(this.address)
+        //   if (bonded) {
+        //     const ledger = await api.query.staking.ledger(bonded)
+        //     const active = ledger?.active || 0n
+        //     free = maxBigInt(data.free - active, 0n)
+        //   }
+        // }
         // End of migration
 
         const balances: AccountBalance = {


### PR DESCRIPTION
- Commented out migration condition for Polkadot
- Removed unused maxBigInt and StakingChain imports 