### PR TITLE
fix: align fast unstake UI eligibility with transaction validation

### DIFF
--- a/packages/app/src/pages/Nominate/Active/ManageBond.tsx
+++ b/packages/app/src/pages/Nominate/Active/ManageBond.tsx
@@ -62,7 +62,7 @@ export const ManageBond = () => {
   const fastUnstakeEligible =
     erasToCheckPerBlock > 0 &&
     !nominationStatus.nominees.active.length &&
-    fastUnstakeStatus !== null &&
+    fastUnstakeStatus?.status === 'NOT_EXPOSED' &&
     !exposed
 
   // Whether unstake buttons should be disabled


### PR DESCRIPTION
The fast unstake button was incorrectly shown to users who were recently active stakers. UI eligibility check only verified `fastUnstakeStatus !== null` while transaction validation required `fastUnstakeStatus?.status === 'NOT_EXPOSED'`.

This caused users to see fast unstake option but receive transaction failures when attempting to register, as they hadn't met the inactivity requirements.

- Update fastUnstakeEligible check to match transaction validation logic
- Require 'NOT_EXPOSED' status instead of any non-null status
- Prevents misleading UI suggestions for recently active stakers

Fixes issue where users unbonding after recent staking activity were incorrectly offered fast unstake option.