### PR TITLE
feat(refactor): Total Nominator Count optimisations

### DIFF
--- a/packages/app/src/contexts/EraStakers/defaults.ts
+++ b/packages/app/src/contexts/EraStakers/defaults.ts
@@ -6,5 +6,4 @@ import type { EraStakers } from './types'
 export const defaultEraStakers: EraStakers = {
   activeAccountOwnStake: [],
   stakers: [],
-  totalActiveNominators: 0,
 }

--- a/packages/app/src/contexts/EraStakers/index.tsx
+++ b/packages/app/src/contexts/EraStakers/index.tsx
@@ -83,7 +83,7 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
     const overviews = await serviceApi.query.erasStakersOverviewEntries(
       activeEra.index
     )
-    // Commit active nominator count from oveviews if staking API is disabled
+    // Commit active nominator count from overviews if staking API is disabled
     if (!pluginEnabled('staking_api')) {
       const totalNominators = overviews.reduce(
         (prev, [, { nominatorCount }]) => prev + nominatorCount,

--- a/packages/app/src/contexts/EraStakers/index.tsx
+++ b/packages/app/src/contexts/EraStakers/index.tsx
@@ -31,6 +31,9 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
   const [eraStakers, setEraStakers] = useState<EraStakers>(defaultEraStakers)
   const eraStakersRef = useRef(eraStakers)
 
+  // Store the total active nominators
+  const [activeNominatorsCount, setActiveNominatorsCount] = useState<number>(0)
+
   // Store active validators
   const [activeValidators, setActiveValidators] = useState<number>(0)
 
@@ -56,11 +59,11 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
         // Syncing current eraStakers is now complete
         removeSyncing('era-stakers')
 
+        setActiveNominatorsCount(totalActiveNominators)
         setStateWithRef(
           {
             ...eraStakersRef.current,
             stakers,
-            totalActiveNominators,
             activeAccountOwnStake,
           },
           setEraStakers,
@@ -191,6 +194,7 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
       value={{
         eraStakers,
         activeValidators,
+        activeNominatorsCount,
         fetchEraStakers,
         getPagedErasStakers,
       }}

--- a/packages/app/src/contexts/EraStakers/index.tsx
+++ b/packages/app/src/contexts/EraStakers/index.tsx
@@ -207,7 +207,7 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
         handleEraTotalNominators()
       }
     }
-  }, [isReady, activeEra.index, pluginEnabled('staking_api')])
+  }, [isReady, activeEra.index, pluginEnabled('staking_api'), activeAddress])
 
   return (
     <EraStakersContext.Provider

--- a/packages/app/src/contexts/EraStakers/types.ts
+++ b/packages/app/src/contexts/EraStakers/types.ts
@@ -6,7 +6,6 @@ export interface EraStakersContextInterface {
   activeValidators: number
   activeNominatorsCount: number
   fetchEraStakers: (era: string) => Promise<Exposure[]>
-  getPagedErasStakers: (e: string) => Promise<Exposure[]>
 }
 
 export interface ActiveAccountOwnStake {

--- a/packages/app/src/contexts/EraStakers/types.ts
+++ b/packages/app/src/contexts/EraStakers/types.ts
@@ -4,6 +4,7 @@
 export interface EraStakersContextInterface {
   eraStakers: EraStakers
   activeValidators: number
+  activeNominatorsCount: number
   fetchEraStakers: (era: string) => Promise<Exposure[]>
   getPagedErasStakers: (e: string) => Promise<Exposure[]>
 }
@@ -15,7 +16,6 @@ export interface ActiveAccountOwnStake {
 export interface EraStakers {
   activeAccountOwnStake: ActiveAccountOwnStake[]
   stakers: Staker[]
-  totalActiveNominators: number
 }
 
 export type Staker = ExposureValue & {

--- a/packages/app/src/pages/Nominate/Active/Stats/ActiveNominators.tsx
+++ b/packages/app/src/pages/Nominate/Active/Stats/ActiveNominators.tsx
@@ -13,15 +13,13 @@ export const ActiveNominators = () => {
   const {
     stakingMetrics: { counterForNominators },
   } = useApi()
-  const {
-    eraStakers: { totalActiveNominators },
-  } = useEraStakers()
+  const { activeNominatorsCount } = useEraStakers()
 
   // active nominators as percent
   let totalNominatorsAsPercent = 0
   if (counterForNominators > 0) {
     totalNominatorsAsPercent = percentageOf(
-      totalActiveNominators,
+      activeNominatorsCount,
       counterForNominators
     )
   }
@@ -29,7 +27,7 @@ export const ActiveNominators = () => {
   const params = {
     label: t('activeNominators'),
     stat: {
-      value: totalActiveNominators,
+      value: activeNominatorsCount,
       total: counterForNominators,
       unit: '',
     },

--- a/packages/app/src/workers/stakers.ts
+++ b/packages/app/src/workers/stakers.ts
@@ -10,7 +10,7 @@ import type { ProcessExposuresArgs } from './types'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const ctx: Worker = self as any
 
-// handle incoming message and route to correct handler.
+// handle incoming message and route to correct handler
 ctx.addEventListener('message', (event: MessageEvent) => {
   const { data } = event
   const { task } = data
@@ -20,9 +20,7 @@ ctx.addEventListener('message', (event: MessageEvent) => {
   }
 })
 
-// process exposures.
-//
-// abstracts active nominators erasStakers.
+// Process exposures with active account stake
 const processExposures = (data: ProcessExposuresArgs) => {
   const { task, networkName, era, units, exposures, activeAccount } = data
 
@@ -37,7 +35,6 @@ const processExposures = (data: ProcessExposuresArgs) => {
         value: o.value,
       })) ?? []
 
-    // Accumulate active nominators and min active stake threshold.
     if (others.length) {
       // Sort `others` by value bonded, largest first.
       others = others.sort((a, b) => {

--- a/packages/app/src/workers/types.ts
+++ b/packages/app/src/workers/types.ts
@@ -19,7 +19,6 @@ export interface ProcessExposuresResponse {
   networkName: NetworkId
   era: string
   stakers: Staker[]
-  totalActiveNominators: number
   activeAccountOwnStake: ActiveAccountStaker[]
   who: MaybeAddress
 }

--- a/packages/plugin-staking-api/src/index.ts
+++ b/packages/plugin-staking-api/src/index.ts
@@ -5,6 +5,7 @@ import { ApolloProvider } from '@apollo/client'
 
 export * from './Client'
 export * from './queries/canFastUnstake'
+export * from './queries/eraTotalNominators'
 export * from './queries/nominatorRewardTrend'
 export * from './queries/poolCandidates'
 export * from './queries/poolEraPoints'

--- a/packages/plugin-staking-api/src/queries/eraTotalNominators.ts
+++ b/packages/plugin-staking-api/src/queries/eraTotalNominators.ts
@@ -1,0 +1,42 @@
+// Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { gql, useQuery } from '@apollo/client'
+import { client } from '../Client'
+import type { EraTotalNominatorsResult } from '../types'
+
+const QUERY = gql`
+  query PoolRewards($network: String!, $who: String!, $from: Int!) {
+    poolRewards(network: $network, who: $who, from: $from) {
+      poolId
+      reward
+      timestamp
+      who
+    }
+  }
+`
+
+export const useEraTotalNominators = ({
+  network,
+  era,
+}: {
+  network: string
+  era: number
+}): EraTotalNominatorsResult => {
+  const { loading, error, data, refetch } = useQuery(QUERY, {
+    variables: { network, era },
+  })
+  return { loading, error, data, refetch }
+}
+
+export const fetchEraTotalNominators = async (network: string, era: number) => {
+  try {
+    const result = await client.query({
+      query: QUERY,
+      variables: { network, era },
+    })
+    return result.data.totalNominators
+  } catch (error) {
+    return null
+  }
+}

--- a/packages/plugin-staking-api/src/queries/eraTotalNominators.ts
+++ b/packages/plugin-staking-api/src/queries/eraTotalNominators.ts
@@ -6,12 +6,9 @@ import { client } from '../Client'
 import type { EraTotalNominatorsResult } from '../types'
 
 const QUERY = gql`
-  query PoolRewards($network: String!, $who: String!, $from: Int!) {
-    poolRewards(network: $network, who: $who, from: $from) {
-      poolId
-      reward
-      timestamp
-      who
+  query EraTotalNominators($network: String!, $era: Int!) {
+    eraTotalNominators(network: $network, era: $era) {
+      totalNominators
     }
   }
 `
@@ -29,14 +26,17 @@ export const useEraTotalNominators = ({
   return { loading, error, data, refetch }
 }
 
-export const fetchEraTotalNominators = async (network: string, era: number) => {
+export const fetchEraTotalNominators = async (
+  network: string,
+  era: number
+): Promise<number | null> => {
   try {
     const result = await client.query({
       query: QUERY,
       variables: { network, era },
     })
-    return result.data.totalNominators
-  } catch (error) {
+    return result.data.eraTotalNominators.totalNominators as number
+  } catch (err) {
     return null
   }
 }

--- a/packages/plugin-staking-api/src/types.ts
+++ b/packages/plugin-staking-api/src/types.ts
@@ -67,6 +67,12 @@ export type PoolRewardResults = Query & {
   }
 }
 
+export type EraTotalNominatorsResult = Query & {
+  data: {
+    totalNominators: number
+  }
+}
+
 export type FastUnstakeStatus =
   | 'UNSUPPORTED_CHAIN'
   | 'NOT_PROCESSED'


### PR DESCRIPTION
This PR optimizes the calculation of total nominator count by introducing a new API endpoint and refactoring the existing worker-based calculation. The changes aim to improve performance by fetching nominator counts from an external API when available, while maintaining backward compatibility.

Key changes:
- Introduces a new `eraTotalNominators` API query for optimized nominator count fetching
- Removes expensive nominator aggregation logic from the staking worker
- Updates context to use either API data or fallback to overview-based calculation
