### PR TITLE
feat: get/set local `activeSection`

### DIFF
--- a/packages/app/src/contexts/UI/defaults.ts
+++ b/packages/app/src/contexts/UI/defaults.ts
@@ -3,3 +3,6 @@
 
 // By default, advanced mode is enabled
 export const defaultAdvancedMode = true
+
+// By default, active section is 'stake'
+export const defaultActiveSection = 'stake'

--- a/packages/app/src/contexts/UI/defaults.ts
+++ b/packages/app/src/contexts/UI/defaults.ts
@@ -1,8 +1,10 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { NavSection } from './types';
+
 // By default, advanced mode is enabled
 export const defaultAdvancedMode = true
 
 // By default, active section is 'stake'
-export const defaultActiveSection = 'stake'
+export const defaultActiveSection: NavSection = 'stake';

--- a/packages/app/src/contexts/UI/defaults.ts
+++ b/packages/app/src/contexts/UI/defaults.ts
@@ -1,10 +1,10 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { NavSection } from './types';
+import type { NavSection } from 'types'
 
 // By default, advanced mode is enabled
 export const defaultAdvancedMode = true
 
 // By default, active section is 'stake'
-export const defaultActiveSection: NavSection = 'stake';
+export const defaultActiveSection: NavSection = 'stake'

--- a/packages/app/src/contexts/UI/index.tsx
+++ b/packages/app/src/contexts/UI/index.tsx
@@ -3,12 +3,16 @@
 
 import { createSafeContext, useEffectIgnoreInitial } from '@w3ux/hooks'
 import { localStorageOrDefault, setStateWithRef } from '@w3ux/utils'
-import { AdvancedModeKey, PageWidthMediumThreshold } from 'consts'
+import {
+	ActiveSectionKey,
+	AdvancedModeKey,
+	PageWidthMediumThreshold,
+} from 'consts'
 import type { ReactNode, RefObject } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import type { AnyJson, NavSection } from 'types'
 import type { UIContextInterface } from './types'
-import { getInitialAdvancedMode } from './util'
+import { getInitialActiveSection, getInitialAdvancedMode } from './util'
 
 export const [UIContext, useUi] = createSafeContext<UIContextInterface>()
 
@@ -25,11 +29,18 @@ export const UIProvider = ({ children }: { children: ReactNode }) => {
 	)
 
 	// The active side bar section
-	const [activeSection, setActiveSection] = useState<NavSection>('stake')
+	const [activeSection, setActiveSectionState] = useState<NavSection>(
+		getInitialActiveSection(),
+	)
 
 	const setAdvancedMode = (value: boolean) => {
 		localStorage.setItem(AdvancedModeKey, String(value))
 		setAdvancedModeState(value)
+	}
+
+	const setActiveSection = (value: NavSection) => {
+		localStorage.setItem(ActiveSectionKey, value)
+		setActiveSectionState(value)
 	}
 
 	// Store references for main app containers

--- a/packages/app/src/contexts/UI/util.ts
+++ b/packages/app/src/contexts/UI/util.ts
@@ -40,7 +40,7 @@ export const getInitialActiveSection = (): NavSection => {
 		if (['stake', 'validators'].includes(localOrDefault)) {
 			return localOrDefault
 		}
-		return localOrDefault
+		return defaultActiveSection
 	} catch {
 		return defaultActiveSection
 	}

--- a/packages/app/src/contexts/UI/util.ts
+++ b/packages/app/src/contexts/UI/util.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { extractUrlValue, localStorageOrDefault } from '@w3ux/utils'
-import { AdvancedModeKey } from 'consts'
-import { defaultAdvancedMode } from './defaults'
+import { ActiveSectionKey, AdvancedModeKey } from 'consts'
+import type { NavSection } from 'types'
+import { defaultActiveSection, defaultAdvancedMode } from './defaults'
 
 // Get the initial advanced mode setting. Prioritises URL, then local storage, then default
 export const getInitialAdvancedMode = (): boolean => {
@@ -25,5 +26,22 @@ export const getInitialAdvancedMode = (): boolean => {
 		// If an error occurs, fall back to the default value
 		localStorage.setItem(AdvancedModeKey, String(defaultAdvancedMode))
 		return defaultAdvancedMode
+	}
+}
+
+// Get the initial active section
+export const getInitialActiveSection = (): NavSection => {
+	try {
+		const localOrDefault = localStorageOrDefault(
+			ActiveSectionKey,
+			'stake',
+		) as NavSection
+
+		if (['stake', 'validators'].includes(localOrDefault)) {
+			return localOrDefault
+		}
+		return localOrDefault
+	} catch {
+		return defaultActiveSection
 	}
 }

--- a/packages/consts/src/index.ts
+++ b/packages/consts/src/index.ts
@@ -38,6 +38,7 @@ export const ProviderTypeKey = 'providerType'
 export const PoolSetupsKey = 'poolSetups'
 export const NominatorSetupsKey = 'nominatorSetups'
 export const AdvancedModeKey = 'advancedMode'
+export const ActiveSectionKey = 'navSection'
 export const ActiveProxiesKey = 'activeProxies'
 
 export const rpcEndpointKey = (network: string) => `${network}RpcEndpoints`


### PR DESCRIPTION
This PR implements functionality to persist and retrieve the active navigation section in local storage, allowing the application to remember the user's last visited section across browser sessions.

- Added local storage support for the `activeSection` state
- Introduced utility function to safely retrieve the initial active section from storage
- Updated the UI context to manage active section persistence with proper getter/setter pattern
