### PR TITLE
feat(refactor): Introduce `useBondActions` hook, tidy up bond logic

### DIFF
--- a/packages/app/src/hooks/useBondActions/index.ts
+++ b/packages/app/src/hooks/useBondActions/index.ts
@@ -49,7 +49,7 @@ export const useBondActions = (): UseBondActions => {
 		canUnstake &&
 		erasToCheckPerBlock > 0 &&
 		!nominationStatus.nominees.active.length &&
-		fastUnstakeStatus !== null &&
+		fastUnstakeStatus?.status === 'NOT_EXPOSED' &&
 		!exposed
 
 	return {

--- a/packages/app/src/hooks/useBondActions/index.ts
+++ b/packages/app/src/hooks/useBondActions/index.ts
@@ -1,0 +1,61 @@
+// Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useActiveAccounts } from 'contexts/ActiveAccounts'
+import { useApi } from 'contexts/Api'
+import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts'
+import { useFastUnstake } from 'contexts/FastUnstake'
+import { useStaking } from 'contexts/Staking'
+import { useNominationStatus } from 'hooks/useNominationStatus'
+import { useSyncing } from 'hooks/useSyncing'
+import { useUnstaking } from 'hooks/useUnstaking'
+import type { UseBondActions } from './types'
+
+export const useBondActions = (): UseBondActions => {
+	const {
+		isReady,
+		stakingMetrics: { erasToCheckPerBlock },
+	} = useApi()
+	const { isBonding } = useStaking()
+	const { isFastUnstaking } = useUnstaking()
+	const { activeAddress } = useActiveAccounts()
+	const { syncing, accountSynced } = useSyncing([
+		'initialization',
+		'era-stakers',
+	])
+	const { isReadOnlyAccount } = useImportedAccounts()
+	const { getNominationStatus } = useNominationStatus()
+	const { exposed, fastUnstakeStatus } = useFastUnstake()
+
+	const isReadOnly = isReadOnlyAccount(activeAddress)
+	const isAccountSynced = accountSynced(activeAddress)
+	const isLoading = !isReady || syncing || !isAccountSynced
+	const nominationStatus = getNominationStatus(activeAddress, 'nominator')
+
+	// Basic requirements: account must exist, not be read-only, and not be syncing
+	const basicRequirements = activeAddress && !isReadOnly && !isLoading
+
+	// Bond actions require basic requirements and bonding capability
+	const canBond = Boolean(basicRequirements && !isFastUnstaking)
+
+	// Unbond actions require basic requirements and active bonding
+	const canUnbond = Boolean(basicRequirements && isBonding && !isFastUnstaking)
+
+	// Unstake actions require basic requirements and active bonding
+	const canUnstake = Boolean(basicRequirements && isBonding)
+
+	// Whether the user can fast unstake
+	const canFastUnstake =
+		canUnstake &&
+		erasToCheckPerBlock > 0 &&
+		!nominationStatus.nominees.active.length &&
+		fastUnstakeStatus !== null &&
+		!exposed
+
+	return {
+		canBond,
+		canUnbond,
+		canUnstake,
+		canFastUnstake,
+	}
+}

--- a/packages/app/src/hooks/useBondActions/types.ts
+++ b/packages/app/src/hooks/useBondActions/types.ts
@@ -1,0 +1,9 @@
+// Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+export interface UseBondActions {
+	canBond: boolean
+	canUnbond: boolean
+	canUnstake: boolean
+	canFastUnstake: boolean
+}


### PR DESCRIPTION
This PR introduces a new `useBondActions` hook to centralize bond-related action logic and simplify the `ManageBond` component. The refactor consolidates complex conditional logic for determining when bonding, unbonding, unstaking, and fast unstaking actions are available.

- Consolidates bond action eligibility logic into a dedicated hook
- Reduces complexity in the ManageBond component by removing inline conditional logic
- Provides a cleaner API with boolean flags for each bond action
