### PR TITLE
feat(refactor): Kusama asset hub migration

### DIFF
--- a/packages/app/src/contexts/FastUnstake/index.tsx
+++ b/packages/app/src/contexts/FastUnstake/index.tsx
@@ -20,6 +20,9 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
 	const [fastUnstakeStatus, setFastUnstakeStatus] =
 		useState<FastUnstakeResult | null>(null)
 
+	// Store fastUnstake eras to check per block
+	const [erasToCheckPerBlock, setErasToCheckPerBlock] = useState<number>(0)
+
 	// Store fastUnstake queue deposit for user
 	const [queueDeposit, setQueueDeposit] = useState<FastUnstakeQueue>()
 
@@ -39,6 +42,7 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
 		const subFastUnstakeConfig = fastUnstakeConfig$.subscribe((result) => {
 			setHead(result.head)
 			setCounterForQueue(result.counterForQueue)
+			setErasToCheckPerBlock(result.erasToCheckPerBlock)
 		})
 		const subFastUnstakeQueue = fastUnstakeQueue$.subscribe((result) => {
 			setQueueDeposit(result)
@@ -56,6 +60,7 @@ export const FastUnstakeProvider = ({ children }: { children: ReactNode }) => {
 				exposed:
 					!!fastUnstakeStatus?.lastExposed &&
 					fastUnstakeStatus?.status === 'EXPOSED',
+				erasToCheckPerBlock,
 				queueDeposit,
 				head,
 				counterForQueue,

--- a/packages/app/src/contexts/FastUnstake/types.ts
+++ b/packages/app/src/contexts/FastUnstake/types.ts
@@ -6,6 +6,7 @@ import type { FastUnstakeHead, FastUnstakeQueue } from 'types'
 
 export interface FastUnstakeContextInterface {
 	exposed: boolean
+	erasToCheckPerBlock: number
 	queueDeposit: FastUnstakeQueue
 	head: FastUnstakeHead | undefined
 	counterForQueue: number | undefined

--- a/packages/app/src/hooks/useBondActions/index.ts
+++ b/packages/app/src/hooks/useBondActions/index.ts
@@ -12,13 +12,11 @@ import { useUnstaking } from 'hooks/useUnstaking'
 import type { UseBondActions } from './types'
 
 export const useBondActions = (): UseBondActions => {
-	const {
-		isReady,
-		stakingMetrics: { erasToCheckPerBlock },
-	} = useApi()
+	const { isReady } = useApi()
 	const { isBonding } = useStaking()
 	const { isFastUnstaking } = useUnstaking()
 	const { activeAddress } = useActiveAccounts()
+	const { erasToCheckPerBlock } = useFastUnstake()
 	const { syncing, accountSynced } = useSyncing([
 		'initialization',
 		'era-stakers',

--- a/packages/app/src/modals/ManageFastUnstake/index.tsx
+++ b/packages/app/src/modals/ManageFastUnstake/index.tsx
@@ -26,22 +26,21 @@ import { Close, useOverlay } from 'ui-overlay'
 export const ManageFastUnstake = () => {
 	const { t } = useTranslation('modals')
 	const {
-		getConsts,
-		activeEra,
-		serviceApi,
-		stakingMetrics: { erasToCheckPerBlock },
-	} = useApi()
+		exposed,
+		queueDeposit,
+		counterForQueue,
+		fastUnstakeStatus,
+		erasToCheckPerBlock,
+	} = useFastUnstake()
 	const { network } = useNetwork()
 	const { feeReserve } = useBalances()
 	const { getTxSubmission } = useTxMeta()
 	const { isFastUnstaking } = useUnstaking()
 	const { activeAddress } = useActiveAccounts()
 	const { getSignerWarnings } = useSignerWarnings()
-	const { setModalResize, setModalStatus } = useOverlay().modal
+	const { getConsts, activeEra, serviceApi } = useApi()
 	const { balances } = useAccountBalances(activeAddress)
-	const { counterForQueue, queueDeposit, fastUnstakeStatus, exposed } =
-		useFastUnstake()
-
+	const { setModalResize, setModalStatus } = useOverlay().modal
 	const { unit, units } = getStakingChainData(network)
 	const { bondDuration, fastUnstakeDeposit } = getConsts(network)
 	const { nominator, transferableBalance } = balances

--- a/packages/dedot-api/src/consts/fastUnstake.ts
+++ b/packages/dedot-api/src/consts/fastUnstake.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { DedotClient } from 'dedot'
-import type { StakingChain } from '../types'
+import type { FastUnstakeChain } from '../types'
 
-export class FastUnstakeConsts<T extends StakingChain> {
+export class FastUnstakeConsts<T extends FastUnstakeChain> {
 	fastUnstakeDeposit: bigint
 
 	constructor(public api: DedotClient<T>) {

--- a/packages/dedot-api/src/consts/fastUnstake.ts
+++ b/packages/dedot-api/src/consts/fastUnstake.ts
@@ -1,0 +1,24 @@
+// Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { DedotClient } from 'dedot'
+import type { StakingChain } from '../types'
+
+export class FastUnstakeConsts<T extends StakingChain> {
+	fastUnstakeDeposit: bigint
+
+	constructor(public api: DedotClient<T>) {
+		this.api = api
+		this.fetch()
+	}
+
+	fetch() {
+		this.fastUnstakeDeposit = this.api.consts.fastUnstake.deposit
+	}
+
+	get() {
+		return {
+			fastUnstakeDeposit: this.fastUnstakeDeposit,
+		}
+	}
+}

--- a/packages/dedot-api/src/consts/staking.ts
+++ b/packages/dedot-api/src/consts/staking.ts
@@ -10,7 +10,6 @@ export class StakingConsts<T extends StakingChain> {
 	sessionsPerEra: number
 	maxExposurePageSize: number
 	historyDepth: number
-	fastUnstakeDeposit: bigint
 	poolsPalletId: Uint8Array
 
 	constructor(public api: DedotClient<T>) {
@@ -23,7 +22,6 @@ export class StakingConsts<T extends StakingChain> {
 		this.sessionsPerEra = this.api.consts.staking.sessionsPerEra
 		this.maxExposurePageSize = this.api.consts.staking.maxExposurePageSize
 		this.historyDepth = this.api.consts.staking.historyDepth
-		this.fastUnstakeDeposit = this.api.consts.fastUnstake.deposit
 		this.poolsPalletId = toU8a(this.api.consts.nominationPools.palletId)
 	}
 
@@ -33,7 +31,6 @@ export class StakingConsts<T extends StakingChain> {
 			sessionsPerEra: this.sessionsPerEra,
 			maxExposurePageSize: this.maxExposurePageSize,
 			historyDepth: this.historyDepth,
-			fastUnstakeDeposit: this.fastUnstakeDeposit,
 			poolsPalletId: this.poolsPalletId,
 		}
 	}

--- a/packages/dedot-api/src/defaultService/baseService.ts
+++ b/packages/dedot-api/src/defaultService/baseService.ts
@@ -71,7 +71,8 @@ export class BaseService<
 		RelayApi,
 		PeopleApi,
 		HubApi,
-		StakingApi
+		StakingApi,
+		FastUnstakeApi
 	>
 
 	constructor(
@@ -81,6 +82,7 @@ export class BaseService<
 		public apiPeople: DedotClient<PeopleApi>,
 		public apiHub: DedotClient<HubApi>,
 		private stakingApi: DedotClient<StakingApi>,
+		private fastUnstakeApi: DedotClient<FastUnstakeApi>,
 	) {
 		this.apiStatus = {
 			relay: new ApiStatus(this.apiRelay, ids[0], networkConfig),
@@ -146,6 +148,7 @@ export class BaseService<
 			this.apiPeople,
 			this.apiHub,
 			this.stakingApi,
+			this.fastUnstakeApi,
 			this.ids,
 			{ poolsPalletId: this.stakingConsts.poolsPalletId },
 			serviceInterface,

--- a/packages/dedot-api/src/defaultService/baseService.ts
+++ b/packages/dedot-api/src/defaultService/baseService.ts
@@ -16,6 +16,7 @@ import type {
 	SystemChainId,
 } from 'types'
 import { CoreConsts } from '../consts/core'
+import { FastUnstakeConsts } from '../consts/fastUnstake'
 import { StakingConsts } from '../consts/staking'
 import { ApiStatus } from '../spec/apiStatus'
 import { ChainSpecs } from '../spec/chainSpecs'
@@ -54,6 +55,7 @@ export class BaseService<
 	// Constants
 	coreConsts: CoreConsts<RelayApi>
 	stakingConsts: StakingConsts<StakingApi>
+	fastUnstakeConsts: FastUnstakeConsts<StakingApi>
 
 	// Query objects
 	blockNumber: BlockNumberQuery<RelayApi>
@@ -106,6 +108,7 @@ export class BaseService<
 		// Initialize constants
 		this.coreConsts = new CoreConsts(this.apiRelay)
 		this.stakingConsts = new StakingConsts(this.stakingApi)
+		this.fastUnstakeConsts = new FastUnstakeConsts(this.stakingApi)
 
 		// Set default sync status
 		setSyncingMulti(defaultSyncStatus)
@@ -126,6 +129,7 @@ export class BaseService<
 		setConsts(this.ids[0], {
 			...this.coreConsts.get(),
 			...this.stakingConsts.get(),
+			...this.fastUnstakeConsts.get(),
 		})
 
 		// Initialize query objects

--- a/packages/dedot-api/src/defaultService/baseService.ts
+++ b/packages/dedot-api/src/defaultService/baseService.ts
@@ -22,7 +22,7 @@ import { ApiStatus } from '../spec/apiStatus'
 import { ChainSpecs } from '../spec/chainSpecs'
 import { ActiveEraQuery } from '../subscribe/activeEra'
 import { BlockNumberQuery } from '../subscribe/blockNumber'
-import { FastUnstakeConfigQuery } from '../subscribe/fastUnstakeConfig'
+import type { FastUnstakeConfigQuery } from '../subscribe/fastUnstakeConfig'
 import { PoolsConfigQuery } from '../subscribe/poolsConfig'
 import { RelayMetricsQuery } from '../subscribe/relayMetrics'
 import type {
@@ -64,7 +64,7 @@ export class BaseService<
 	activeEra: ActiveEraQuery<StakingApi>
 	relayMetrics: RelayMetricsQuery<RelayApi>
 	poolsConfig: PoolsConfigQuery<StakingApi>
-	fastUnstakeConfig: FastUnstakeConfigQuery<StakingApi>
+	fastUnstakeConfig: FastUnstakeConfigQuery<FastUnstakeApi>
 
 	// Subscription manager
 	subscriptionManager: SubscriptionManager<
@@ -140,7 +140,6 @@ export class BaseService<
 		this.activeEra = new ActiveEraQuery(this.stakingApi)
 		this.relayMetrics = new RelayMetricsQuery(this.apiRelay)
 		this.poolsConfig = new PoolsConfigQuery(this.stakingApi)
-		this.fastUnstakeConfig = new FastUnstakeConfigQuery(this.stakingApi)
 
 		// Initialize subscription manager
 		this.subscriptionManager = new SubscriptionManager(

--- a/packages/dedot-api/src/defaultService/baseService.ts
+++ b/packages/dedot-api/src/defaultService/baseService.ts
@@ -16,7 +16,7 @@ import type {
 	SystemChainId,
 } from 'types'
 import { CoreConsts } from '../consts/core'
-import { FastUnstakeConsts } from '../consts/fastUnstake'
+import type { FastUnstakeConsts } from '../consts/fastUnstake'
 import { StakingConsts } from '../consts/staking'
 import { ApiStatus } from '../spec/apiStatus'
 import { ChainSpecs } from '../spec/chainSpecs'
@@ -27,6 +27,7 @@ import { PoolsConfigQuery } from '../subscribe/poolsConfig'
 import { RelayMetricsQuery } from '../subscribe/relayMetrics'
 import type {
 	AssetHubChain,
+	FastUnstakeChain,
 	PeopleChain,
 	RelayChain,
 	StakingChain,
@@ -39,6 +40,7 @@ export class BaseService<
 	PeopleApi extends PeopleChain,
 	HubApi extends AssetHubChain,
 	StakingApi extends StakingChain,
+	FastUnstakeApi extends FastUnstakeChain,
 > {
 	// Chain specs
 	relayChainSpec: ChainSpecs<RelayApi>
@@ -55,7 +57,7 @@ export class BaseService<
 	// Constants
 	coreConsts: CoreConsts<RelayApi>
 	stakingConsts: StakingConsts<StakingApi>
-	fastUnstakeConsts: FastUnstakeConsts<StakingApi>
+	fastUnstakeConsts: FastUnstakeConsts<FastUnstakeApi>
 
 	// Query objects
 	blockNumber: BlockNumberQuery<RelayApi>
@@ -108,7 +110,6 @@ export class BaseService<
 		// Initialize constants
 		this.coreConsts = new CoreConsts(this.apiRelay)
 		this.stakingConsts = new StakingConsts(this.stakingApi)
-		this.fastUnstakeConsts = new FastUnstakeConsts(this.stakingApi)
 
 		// Set default sync status
 		setSyncingMulti(defaultSyncStatus)

--- a/packages/dedot-api/src/defaultService/subscriptionManager.ts
+++ b/packages/dedot-api/src/defaultService/subscriptionManager.ts
@@ -31,6 +31,7 @@ import type {
 	ActivePools,
 	AssetHubChain,
 	BondedAccounts,
+	FastUnstakeChain,
 	PeopleChain,
 	PoolMemberships,
 	Proxies,
@@ -54,6 +55,7 @@ export class SubscriptionManager<
 	PeopleApi extends PeopleChain,
 	HubApi extends AssetHubChain,
 	StakingApi extends StakingChain,
+	FastUnstakeApi extends FastUnstakeChain,
 > {
 	subActiveAddress: Subscription
 	subImportedAccounts: Subscription
@@ -75,13 +77,14 @@ export class SubscriptionManager<
 	// Query objects that may need to be recreated
 	stakingMetrics: StakingMetricsQuery<StakingApi>
 	eraRewardPoints: EraRewardPointsQuery<StakingApi>
-	fastUnstakeQueue: FastUnstakeQueueQuery<StakingApi>
+	fastUnstakeQueue: FastUnstakeQueueQuery<FastUnstakeApi>
 
 	constructor(
 		private apiRelay: DedotClient<RelayApi>,
 		private apiPeople: DedotClient<PeopleApi>,
 		private apiHub: DedotClient<HubApi>,
 		private stakingApi: DedotClient<StakingApi>,
+		private fastUnstakeApi: DedotClient<FastUnstakeApi>,
 		private ids: [NetworkId, SystemChainId, SystemChainId],
 		private stakingConsts: { poolsPalletId: Uint8Array },
 		private serviceInterface: ServiceInterface,
@@ -94,7 +97,7 @@ export class SubscriptionManager<
 			if (activeAddress) {
 				this.fastUnstakeQueue?.unsubscribe()
 				this.fastUnstakeQueue = new FastUnstakeQueueQuery(
-					this.stakingApi,
+					this.fastUnstakeApi,
 					activeAddress,
 				)
 			}

--- a/packages/dedot-api/src/defaultService/types.ts
+++ b/packages/dedot-api/src/defaultService/types.ts
@@ -79,7 +79,7 @@ export abstract class DefaultServiceClass<
 	abstract poolsConfig: PoolsConfigQuery<StakingApi>
 	abstract stakingMetrics: StakingMetricsQuery<StakingApi>
 	abstract eraRewardPoints: EraRewardPointsQuery<StakingApi>
-	abstract fastUnstakeConfig: FastUnstakeConfigQuery<StakingApi>
+	abstract fastUnstakeConfig: FastUnstakeConfigQuery<FastUnstakeApi>
 	abstract fastUnstakeQueue: FastUnstakeQueueQuery<FastUnstakeApi>
 
 	subActiveAddress: Subscription

--- a/packages/dedot-api/src/defaultService/types.ts
+++ b/packages/dedot-api/src/defaultService/types.ts
@@ -10,6 +10,7 @@ import type {
 	SystemChainId,
 } from 'types'
 import type { CoreConsts } from '../consts/core'
+import type { FastUnstakeConsts } from '../consts/fastUnstake'
 import type { StakingConsts } from '../consts/staking'
 import type { ApiStatus } from '../spec/apiStatus'
 import type { ChainSpecs } from '../spec/chainSpecs'
@@ -26,6 +27,7 @@ import type {
 	ActivePools,
 	AssetHubChain,
 	BondedAccounts,
+	FastUnstakeChain,
 	PeopleChain,
 	PoolMemberships,
 	Proxies,
@@ -43,6 +45,7 @@ export abstract class DefaultServiceClass<
 	PeopleApi extends PeopleChain,
 	HubApi extends AssetHubChain,
 	StakingApi extends StakingChain,
+	FastUnstakeApi extends FastUnstakeChain,
 > extends ServiceClass {
 	constructor(
 		public networkConfig: NetworkConfig,
@@ -68,6 +71,8 @@ export abstract class DefaultServiceClass<
 
 	abstract coreConsts: CoreConsts<RelayApi>
 	abstract stakingConsts: StakingConsts<StakingApi>
+	abstract fastUnstakeConsts: FastUnstakeConsts<FastUnstakeApi>
+
 	abstract blockNumber: BlockNumberQuery<RelayApi>
 	abstract activeEra: ActiveEraQuery<StakingApi>
 	abstract relayMetrics: RelayMetricsQuery<RelayApi>

--- a/packages/dedot-api/src/defaultService/types.ts
+++ b/packages/dedot-api/src/defaultService/types.ts
@@ -80,7 +80,7 @@ export abstract class DefaultServiceClass<
 	abstract stakingMetrics: StakingMetricsQuery<StakingApi>
 	abstract eraRewardPoints: EraRewardPointsQuery<StakingApi>
 	abstract fastUnstakeConfig: FastUnstakeConfigQuery<StakingApi>
-	abstract fastUnstakeQueue: FastUnstakeQueueQuery<StakingApi>
+	abstract fastUnstakeQueue: FastUnstakeQueueQuery<FastUnstakeApi>
 
 	subActiveAddress: Subscription
 	subImportedAccounts: Subscription

--- a/packages/dedot-api/src/services/kusama.ts
+++ b/packages/dedot-api/src/services/kusama.ts
@@ -46,8 +46,8 @@ export class KusamaService
 		public apiPeople: DedotClient<KusamaPeopleApi>,
 		public apiHub: DedotClient<KusamaAssetHubApi>,
 	) {
-		// For Kusama, staking happens on the relay chain
-		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiHub)
+		// For Kusama, staking happens on the hub chain, and fast unstake on the relay chain
+		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiHub, apiRelay)
 
 		// For Kusama, fast unstake happens on the relay chain
 		this.fastUnstakeConsts = new FastUnstakeConsts(this.apiRelay)

--- a/packages/dedot-api/src/services/kusama.ts
+++ b/packages/dedot-api/src/services/kusama.ts
@@ -21,19 +21,19 @@ import { createPool } from '../tx/createPool'
 
 export class KusamaService
 	extends BaseService<
-		KusamaApi,
-		KusamaPeopleApi,
-		KusamaAssetHubApi,
-		KusamaAssetHubApi,
-		KusamaApi
+		KusamaApi, // Relay Chain
+		KusamaPeopleApi, // People Chain
+		KusamaAssetHubApi, // Asset Hub Chain
+		KusamaAssetHubApi, // Chain for staking
+		KusamaApi // Chain for fast unstake
 	>
 	implements
 		DefaultServiceClass<
-			KusamaApi,
-			KusamaPeopleApi,
-			KusamaAssetHubApi,
-			KusamaAssetHubApi,
-			KusamaApi
+			KusamaApi, // Relay Chain
+			KusamaPeopleApi, // People Chain
+			KusamaAssetHubApi, // Asset Hub Chain
+			KusamaAssetHubApi, // Chain for staking
+			KusamaApi // Chain for fast unstake
 		>
 {
 	// Service interface

--- a/packages/dedot-api/src/services/kusama.ts
+++ b/packages/dedot-api/src/services/kusama.ts
@@ -106,8 +106,8 @@ export class KusamaService
 						nominees,
 						roles,
 					),
-				fastUnstakeDeregister: () => tx.fastUnstakeDeregister(this.apiHub),
-				fastUnstakeRegister: () => tx.fastUnstakeRegister(this.apiHub),
+				fastUnstakeDeregister: () => tx.fastUnstakeDeregister(this.apiRelay),
+				fastUnstakeRegister: () => tx.fastUnstakeRegister(this.apiRelay),
 				joinPool: (poolId, bond, claimPermission) =>
 					tx.joinPool(this.apiHub, poolId, bond, claimPermission),
 				newNominator: (bond, payee, nominees) =>

--- a/packages/dedot-api/src/services/kusama.ts
+++ b/packages/dedot-api/src/services/kusama.ts
@@ -19,13 +19,18 @@ import { tx } from '../tx'
 import { createPool } from '../tx/createPool'
 
 export class KusamaService
-	extends BaseService<KusamaApi, KusamaPeopleApi, KusamaAssetHubApi, KusamaApi>
+	extends BaseService<
+		KusamaApi,
+		KusamaPeopleApi,
+		KusamaAssetHubApi,
+		KusamaAssetHubApi
+	>
 	implements
 		DefaultServiceClass<
 			KusamaApi,
 			KusamaPeopleApi,
 			KusamaAssetHubApi,
-			KusamaApi
+			KusamaAssetHubApi
 		>
 {
 	// Service interface
@@ -39,56 +44,55 @@ export class KusamaService
 		public apiHub: DedotClient<KusamaAssetHubApi>,
 	) {
 		// For Kusama, staking happens on the relay chain
-		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiRelay)
+		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiHub)
 
 		// Initialize service interface with network-specific routing
 		this.interface = {
 			query: {
 				erasValidatorRewardMulti: async (eras) =>
-					await query.erasValidatorRewardMulti(this.apiRelay, eras),
+					await query.erasValidatorRewardMulti(this.apiHub, eras),
 				bondedPool: async (poolId) =>
-					await query.bondedPool(this.apiRelay, poolId),
+					await query.bondedPool(this.apiHub, poolId),
 				bondedPoolEntries: async () =>
-					await query.bondedPoolEntries(this.apiRelay),
+					await query.bondedPoolEntries(this.apiHub),
 				erasStakersOverviewEntries: async (era) =>
-					await query.erasStakersOverviewEntries(this.apiRelay, era),
+					await query.erasStakersOverviewEntries(this.apiHub, era),
 				erasStakersPagedEntries: async (era, validator) =>
-					await query.erasStakersPagedEntries(this.apiRelay, era, validator),
+					await query.erasStakersPagedEntries(this.apiHub, era, validator),
 				identityOfMulti: async (addresses) =>
 					await query.identityOfMulti(this.apiPeople, addresses),
 				nominatorsMulti: async (addresses) =>
-					await query.nominatorsMulti(this.apiRelay, addresses),
+					await query.nominatorsMulti(this.apiHub, addresses),
 				poolMembersMulti: async (addresses) =>
-					await query.poolMembersMulti(this.apiRelay, addresses),
+					await query.poolMembersMulti(this.apiHub, addresses),
 				poolMetadataMulti: async (poolIds) =>
-					await query.poolMetadataMulti(this.apiRelay, poolIds),
-				proxies: async (address) => await query.proxies(this.apiRelay, address),
+					await query.poolMetadataMulti(this.apiHub, poolIds),
+				proxies: async (address) => await query.proxies(this.apiHub, address),
 				sessionValidators: async () =>
-					await query.sessionValidators(this.apiRelay),
+					await query.sessionValidators(this.apiHub),
 				superOfMulti: async (addresses) =>
 					await query.superOfMulti(
 						this.apiPeople,
 						addresses,
 						this.apiPeople.consts.system.ss58Prefix,
 					),
-				validatorEntries: async () =>
-					await query.validatorEntries(this.apiRelay),
+				validatorEntries: async () => await query.validatorEntries(this.apiHub),
 				validatorsMulti: async (addresses) =>
-					await query.validatorsMulti(this.apiRelay, addresses),
+					await query.validatorsMulti(this.apiHub, addresses),
 			},
 			runtimeApi: {
 				balanceToPoints: async (poolId, amount) =>
-					await runtimeApi.balanceToPoints(this.apiRelay, poolId, amount),
+					await runtimeApi.balanceToPoints(this.apiHub, poolId, amount),
 				pendingRewards: async (address) =>
-					await runtimeApi.pendingRewards(this.apiRelay, address),
+					await runtimeApi.pendingRewards(this.apiHub, address),
 				pointsToBalance: async (poolId, points) =>
-					await runtimeApi.pointsToBalance(this.apiRelay, poolId, points),
+					await runtimeApi.pointsToBalance(this.apiHub, poolId, points),
 			},
 			tx: {
-				batch: (calls) => tx.batch(this.apiRelay, calls),
+				batch: (calls) => tx.batch(this.apiHub, calls),
 				createPool: (from, poolId, bond, metadata, nominees, roles) =>
 					createPool(
-						this.apiRelay,
+						this.apiHub,
 						from,
 						poolId,
 						bond,
@@ -96,57 +100,57 @@ export class KusamaService
 						nominees,
 						roles,
 					),
-				fastUnstakeDeregister: () => tx.fastUnstakeDeregister(this.apiRelay),
-				fastUnstakeRegister: () => tx.fastUnstakeRegister(this.apiRelay),
+				fastUnstakeDeregister: () => tx.fastUnstakeDeregister(this.apiHub),
+				fastUnstakeRegister: () => tx.fastUnstakeRegister(this.apiHub),
 				joinPool: (poolId, bond, claimPermission) =>
-					tx.joinPool(this.apiRelay, poolId, bond, claimPermission),
+					tx.joinPool(this.apiHub, poolId, bond, claimPermission),
 				newNominator: (bond, payee, nominees) =>
-					tx.newNominator(this.apiRelay, bond, payee, nominees),
+					tx.newNominator(this.apiHub, bond, payee, nominees),
 				payoutStakersByPage: (validator, era, page) =>
-					tx.payoutStakersByPage(this.apiRelay, validator, era, page),
+					tx.payoutStakersByPage(this.apiHub, validator, era, page),
 				poolBondExtra: (type, bond) =>
-					tx.poolBondExtra(this.apiRelay, type, bond),
-				poolChill: (poolId) => tx.poolChill(this.apiRelay, poolId),
+					tx.poolBondExtra(this.apiHub, type, bond),
+				poolChill: (poolId) => tx.poolChill(this.apiHub, poolId),
 				poolClaimCommission: (poolId) =>
-					tx.poolClaimCommission(this.apiRelay, poolId),
-				poolClaimPayout: () => tx.poolClaimPayout(this.apiRelay),
+					tx.poolClaimCommission(this.apiHub, poolId),
+				poolClaimPayout: () => tx.poolClaimPayout(this.apiHub),
 				poolNominate: (poolId, nominees) =>
-					tx.poolNominate(this.apiRelay, poolId, nominees),
+					tx.poolNominate(this.apiHub, poolId, nominees),
 				poolSetClaimPermission: (claimPermission) =>
-					tx.poolSetClaimPermission(this.apiRelay, claimPermission),
+					tx.poolSetClaimPermission(this.apiHub, claimPermission),
 				poolSetCommission: (poolId, commission) =>
-					tx.poolSetCommission(this.apiRelay, poolId, commission),
+					tx.poolSetCommission(this.apiHub, poolId, commission),
 				poolSetCommissionChangeRate: (poolId, maxIncrease, minDelay) =>
 					tx.poolSetCommissionChangeRate(
-						this.apiRelay,
+						this.apiHub,
 						poolId,
 						maxIncrease,
 						minDelay,
 					),
 				poolSetCommissionMax: (poolId, max) =>
-					tx.poolSetCommissionMax(this.apiRelay, poolId, max),
+					tx.poolSetCommissionMax(this.apiHub, poolId, max),
 				poolSetMetadata: (poolId, metadata) =>
-					tx.poolSetMetadata(this.apiRelay, poolId, metadata),
+					tx.poolSetMetadata(this.apiHub, poolId, metadata),
 				poolSetState: (poolId, state) =>
-					tx.poolSetState(this.apiRelay, poolId, state),
-				poolUnbond: (who, points) => tx.poolUnbond(this.apiRelay, who, points),
+					tx.poolSetState(this.apiHub, poolId, state),
+				poolUnbond: (who, points) => tx.poolUnbond(this.apiHub, who, points),
 				poolUpdateRoles: (poolId, roles) =>
-					tx.poolUpdateRoles(this.apiRelay, poolId, roles),
+					tx.poolUpdateRoles(this.apiHub, poolId, roles),
 				poolWithdraw: (who, numSlashingSpans) =>
-					tx.poolWithdraw(this.apiRelay, who, numSlashingSpans),
-				proxy: (real, call) => tx.proxy(this.apiRelay, real, call),
-				setController: () => tx.setController(this.apiRelay),
-				stakingBondExtra: (bond) => tx.stakingBondExtra(this.apiRelay, bond),
-				stakingChill: () => tx.stakingChill(this.apiRelay),
+					tx.poolWithdraw(this.apiHub, who, numSlashingSpans),
+				proxy: (real, call) => tx.proxy(this.apiHub, real, call),
+				setController: () => tx.setController(this.apiHub),
+				stakingBondExtra: (bond) => tx.stakingBondExtra(this.apiHub, bond),
+				stakingChill: () => tx.stakingChill(this.apiHub),
 				stakingNominate: (nominees) =>
-					tx.stakingNominate(this.apiRelay, nominees),
-				stakingRebond: (bond) => tx.stakingRebond(this.apiRelay, bond),
-				stakingSetPayee: (payee) => tx.stakingSetPayee(this.apiRelay, payee),
-				stakingUnbond: (bond) => tx.stakingUnbond(this.apiRelay, bond),
+					tx.stakingNominate(this.apiHub, nominees),
+				stakingRebond: (bond) => tx.stakingRebond(this.apiHub, bond),
+				stakingSetPayee: (payee) => tx.stakingSetPayee(this.apiHub, payee),
+				stakingUnbond: (bond) => tx.stakingUnbond(this.apiHub, bond),
 				stakingWithdraw: (numSlashingSpans) =>
-					tx.stakingWithdraw(this.apiRelay, numSlashingSpans),
+					tx.stakingWithdraw(this.apiHub, numSlashingSpans),
 				transferKeepAlive: (to, value) =>
-					tx.transferKeepAlive(this.apiRelay, to, value),
+					tx.transferKeepAlive(this.apiHub, to, value),
 			},
 			signer: {
 				extraSignedExtension: (

--- a/packages/dedot-api/src/services/kusama.ts
+++ b/packages/dedot-api/src/services/kusama.ts
@@ -11,6 +11,7 @@ import type {
 	ServiceInterface,
 	SystemChainId,
 } from 'types'
+import { FastUnstakeConsts } from '../consts/fastUnstake'
 import { BaseService } from '../defaultService/baseService'
 import type { DefaultServiceClass } from '../defaultService/types'
 import { query } from '../query'
@@ -23,14 +24,16 @@ export class KusamaService
 		KusamaApi,
 		KusamaPeopleApi,
 		KusamaAssetHubApi,
-		KusamaAssetHubApi
+		KusamaAssetHubApi,
+		KusamaApi
 	>
 	implements
 		DefaultServiceClass<
 			KusamaApi,
 			KusamaPeopleApi,
 			KusamaAssetHubApi,
-			KusamaAssetHubApi
+			KusamaAssetHubApi,
+			KusamaApi
 		>
 {
 	// Service interface
@@ -45,6 +48,9 @@ export class KusamaService
 	) {
 		// For Kusama, staking happens on the relay chain
 		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiHub)
+
+		// For Kusama, fast unstake happens on the relay chain
+		this.fastUnstakeConsts = new FastUnstakeConsts(this.apiRelay)
 
 		// Initialize service interface with network-specific routing
 		this.interface = {

--- a/packages/dedot-api/src/services/kusama.ts
+++ b/packages/dedot-api/src/services/kusama.ts
@@ -16,6 +16,7 @@ import { BaseService } from '../defaultService/baseService'
 import type { DefaultServiceClass } from '../defaultService/types'
 import { query } from '../query'
 import { runtimeApi } from '../runtimeApi'
+import { FastUnstakeConfigQuery } from '../subscribe/fastUnstakeConfig'
 import { tx } from '../tx'
 import { createPool } from '../tx/createPool'
 
@@ -51,6 +52,7 @@ export class KusamaService
 
 		// For Kusama, fast unstake happens on the relay chain
 		this.fastUnstakeConsts = new FastUnstakeConsts(this.apiRelay)
+		this.fastUnstakeConfig = new FastUnstakeConfigQuery(this.apiRelay)
 
 		// Initialize service interface with network-specific routing
 		this.interface = {

--- a/packages/dedot-api/src/services/polkadot.ts
+++ b/packages/dedot-api/src/services/polkadot.ts
@@ -11,6 +11,7 @@ import type {
 	ServiceInterface,
 	SystemChainId,
 } from 'types'
+import { FastUnstakeConsts } from '../consts/fastUnstake'
 import { BaseService } from '../defaultService/baseService'
 import type { DefaultServiceClass } from '../defaultService/types'
 import { query } from '../query'
@@ -23,6 +24,7 @@ export class PolkadotService
 		PolkadotApi,
 		PolkadotPeopleApi,
 		PolkadotAssetHubApi,
+		PolkadotApi,
 		PolkadotApi
 	>
 	implements
@@ -30,6 +32,7 @@ export class PolkadotService
 			PolkadotApi,
 			PolkadotPeopleApi,
 			PolkadotAssetHubApi,
+			PolkadotApi,
 			PolkadotApi
 		>
 {
@@ -45,6 +48,9 @@ export class PolkadotService
 	) {
 		// For Polkadot, staking happens on the relay chain
 		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiRelay)
+
+		// For Polkadot, fast unstake happens on the relay chain
+		this.fastUnstakeConsts = new FastUnstakeConsts(this.apiRelay)
 
 		// Initialize service interface with network-specific routing
 		this.interface = {

--- a/packages/dedot-api/src/services/polkadot.ts
+++ b/packages/dedot-api/src/services/polkadot.ts
@@ -16,6 +16,7 @@ import { BaseService } from '../defaultService/baseService'
 import type { DefaultServiceClass } from '../defaultService/types'
 import { query } from '../query'
 import { runtimeApi } from '../runtimeApi'
+import { FastUnstakeConfigQuery } from '../subscribe/fastUnstakeConfig'
 import { tx } from '../tx'
 import { createPool } from '../tx/createPool'
 
@@ -51,6 +52,7 @@ export class PolkadotService
 
 		// For Polkadot, fast unstake happens on the relay chain
 		this.fastUnstakeConsts = new FastUnstakeConsts(this.apiRelay)
+		this.fastUnstakeConfig = new FastUnstakeConfigQuery(this.apiRelay)
 
 		// Initialize service interface with network-specific routing
 		this.interface = {

--- a/packages/dedot-api/src/services/polkadot.ts
+++ b/packages/dedot-api/src/services/polkadot.ts
@@ -46,8 +46,8 @@ export class PolkadotService
 		public apiPeople: DedotClient<PolkadotPeopleApi>,
 		public apiHub: DedotClient<PolkadotAssetHubApi>,
 	) {
-		// For Polkadot, staking happens on the relay chain
-		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiRelay)
+		// For Polkadot, staking happens on the relay chain, and fast unstake on the relay chain
+		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiRelay, apiRelay)
 
 		// For Polkadot, fast unstake happens on the relay chain
 		this.fastUnstakeConsts = new FastUnstakeConsts(this.apiRelay)

--- a/packages/dedot-api/src/services/polkadot.ts
+++ b/packages/dedot-api/src/services/polkadot.ts
@@ -21,19 +21,19 @@ import { createPool } from '../tx/createPool'
 
 export class PolkadotService
 	extends BaseService<
-		PolkadotApi,
-		PolkadotPeopleApi,
-		PolkadotAssetHubApi,
-		PolkadotApi,
-		PolkadotApi
+		PolkadotApi, // Relay Chain
+		PolkadotPeopleApi, // People Chain
+		PolkadotAssetHubApi, // Asset Hub Chain
+		PolkadotApi, // Chain for staking
+		PolkadotApi // Chain for fast unstake
 	>
 	implements
 		DefaultServiceClass<
-			PolkadotApi,
-			PolkadotPeopleApi,
-			PolkadotAssetHubApi,
-			PolkadotApi,
-			PolkadotApi
+			PolkadotApi, // Relay Chain
+			PolkadotPeopleApi, // People Chain
+			PolkadotAssetHubApi, // Asset Hub Chain
+			PolkadotApi, // Chain for staking
+			PolkadotApi // Chain for fast unstake
 		>
 {
 	// Service interface

--- a/packages/dedot-api/src/services/westend.ts
+++ b/packages/dedot-api/src/services/westend.ts
@@ -21,19 +21,19 @@ import { createPool } from '../tx/createPool'
 
 export class WestendService
 	extends BaseService<
-		WestendApi,
-		WestendPeopleApi,
-		WestendAssetHubApi,
-		WestendAssetHubApi,
-		WestendAssetHubApi
+		WestendApi, // Relay Chain
+		WestendPeopleApi, // People Chain
+		WestendAssetHubApi, // Asset Hub Chain
+		WestendAssetHubApi, // Chain for staking
+		WestendAssetHubApi // Chain for fast unstake
 	>
 	implements
 		DefaultServiceClass<
-			WestendApi,
-			WestendPeopleApi,
-			WestendAssetHubApi,
-			WestendAssetHubApi,
-			WestendAssetHubApi
+			WestendApi, // Relay Chain
+			WestendPeopleApi, // People Chain
+			WestendAssetHubApi, // Asset Hub Chain
+			WestendAssetHubApi, // Chain for staking
+			WestendAssetHubApi // Chain for fast unstake
 		>
 {
 	// Service interface

--- a/packages/dedot-api/src/services/westend.ts
+++ b/packages/dedot-api/src/services/westend.ts
@@ -16,6 +16,7 @@ import { BaseService } from '../defaultService/baseService'
 import type { DefaultServiceClass } from '../defaultService/types'
 import { query } from '../query'
 import { runtimeApi } from '../runtimeApi'
+import { FastUnstakeConfigQuery } from '../subscribe/fastUnstakeConfig'
 import { tx } from '../tx'
 import { createPool } from '../tx/createPool'
 
@@ -51,6 +52,7 @@ export class WestendService
 
 		// For Westend, fast unstake happens on the asset hub chain
 		this.fastUnstakeConsts = new FastUnstakeConsts(this.apiHub)
+		this.fastUnstakeConfig = new FastUnstakeConfigQuery(this.apiHub)
 
 		// Initialize service interface with network-specific routing
 		this.interface = {

--- a/packages/dedot-api/src/services/westend.ts
+++ b/packages/dedot-api/src/services/westend.ts
@@ -11,6 +11,7 @@ import type {
 	ServiceInterface,
 	SystemChainId,
 } from 'types'
+import { FastUnstakeConsts } from '../consts/fastUnstake'
 import { BaseService } from '../defaultService/baseService'
 import type { DefaultServiceClass } from '../defaultService/types'
 import { query } from '../query'
@@ -23,12 +24,14 @@ export class WestendService
 		WestendApi,
 		WestendPeopleApi,
 		WestendAssetHubApi,
+		WestendAssetHubApi,
 		WestendAssetHubApi
 	>
 	implements
 		DefaultServiceClass<
 			WestendApi,
 			WestendPeopleApi,
+			WestendAssetHubApi,
 			WestendAssetHubApi,
 			WestendAssetHubApi
 		>
@@ -45,6 +48,9 @@ export class WestendService
 	) {
 		// For Westend, staking happens on asset hub
 		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiHub)
+
+		// For Westend, fast unstake happens on the asset hub chain
+		this.fastUnstakeConsts = new FastUnstakeConsts(this.apiHub)
 
 		// Initialize service interface with network-specific routing
 		this.interface = {

--- a/packages/dedot-api/src/services/westend.ts
+++ b/packages/dedot-api/src/services/westend.ts
@@ -46,8 +46,8 @@ export class WestendService
 		public apiPeople: DedotClient<WestendPeopleApi>,
 		public apiHub: DedotClient<WestendAssetHubApi>,
 	) {
-		// For Westend, staking happens on asset hub
-		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiHub)
+		// For Westend, staking happens on the hub chain, and fast unstake on the hub chain
+		super(networkConfig, ids, apiRelay, apiPeople, apiHub, apiHub, apiHub)
 
 		// For Westend, fast unstake happens on the asset hub chain
 		this.fastUnstakeConsts = new FastUnstakeConsts(this.apiHub)

--- a/packages/dedot-api/src/subscribe/fastUnstakeConfig.ts
+++ b/packages/dedot-api/src/subscribe/fastUnstakeConfig.ts
@@ -5,9 +5,9 @@ import type { DedotClient } from 'dedot'
 import type { Unsub } from 'dedot/types'
 import { defaultFastUnstakeConfig, setFastUnstakeConfig } from 'global-bus'
 import type { FastUnstakeConfig } from 'types'
-import type { StakingChain } from '../types'
+import type { FastUnstakeChain } from '../types'
 
-export class FastUnstakeConfigQuery<T extends StakingChain> {
+export class FastUnstakeConfigQuery<T extends FastUnstakeChain> {
 	config: FastUnstakeConfig = defaultFastUnstakeConfig
 
 	#unsub: Unsub | undefined = undefined

--- a/packages/dedot-api/src/subscribe/fastUnstakeConfig.ts
+++ b/packages/dedot-api/src/subscribe/fastUnstakeConfig.ts
@@ -8,6 +8,7 @@ import type { FastUnstakeConfig } from 'types'
 import type { FastUnstakeChain } from '../types'
 
 export class FastUnstakeConfigQuery<T extends FastUnstakeChain> {
+	erasToCheckPerBlock: number = 0
 	config: FastUnstakeConfig = defaultFastUnstakeConfig
 
 	#unsub: Unsub | undefined = undefined
@@ -21,6 +22,10 @@ export class FastUnstakeConfigQuery<T extends FastUnstakeChain> {
 		this.#unsub = await this.api.queryMulti(
 			[
 				{
+					fn: this.api.query.fastUnstake.erasToCheckPerBlock,
+					args: [],
+				},
+				{
 					fn: this.api.query.fastUnstake.head,
 					args: [],
 				},
@@ -29,17 +34,17 @@ export class FastUnstakeConfigQuery<T extends FastUnstakeChain> {
 					args: [],
 				},
 			],
-			([head, counterForQueue]) => {
+			([erasToCheckPerBlock, head, counterForQueue]) => {
 				const stashes = head?.stashes || []
 				const checked = head?.checked || []
-				const config = {
+				this.config = {
+					erasToCheckPerBlock,
 					head: {
 						stashes,
 						checked,
 					},
 					counterForQueue,
 				}
-				this.config = config
 				setFastUnstakeConfig(this.config)
 			},
 		)

--- a/packages/dedot-api/src/subscribe/fastUnstakeQueue.ts
+++ b/packages/dedot-api/src/subscribe/fastUnstakeQueue.ts
@@ -4,9 +4,9 @@
 import type { DedotClient } from 'dedot'
 import type { Unsub } from 'dedot/types'
 import { setFastUnstakeQueue } from 'global-bus'
-import type { StakingChain } from '../types'
+import type { FastUnstakeChain } from '../types'
 
-export class FastUnstakeQueueQuery<T extends StakingChain> {
+export class FastUnstakeQueueQuery<T extends FastUnstakeChain> {
 	queue: bigint = 0n
 
 	#unsub: Unsub | undefined = undefined

--- a/packages/dedot-api/src/subscribe/stakingMetrics.ts
+++ b/packages/dedot-api/src/subscribe/stakingMetrics.ts
@@ -28,10 +28,6 @@ export class StakingMetricsQuery<T extends StakingChain> {
 					args: [],
 				},
 				{
-					fn: this.api.query.fastUnstake.erasToCheckPerBlock,
-					args: [],
-				},
-				{
 					fn: this.api.query.staking.minimumActiveStake,
 					args: [],
 				},
@@ -70,7 +66,6 @@ export class StakingMetricsQuery<T extends StakingChain> {
 			],
 			([
 				totalIssuance,
-				erasToCheckPerBlock,
 				minimumActiveStake,
 				counterForValidators,
 				maxValidatorsCount,
@@ -83,7 +78,6 @@ export class StakingMetricsQuery<T extends StakingChain> {
 			]) => {
 				this.stakingMetrics = {
 					totalIssuance,
-					erasToCheckPerBlock,
 					minimumActiveStake,
 					counterForValidators,
 					maxValidatorsCount,

--- a/packages/dedot-api/src/tx/fastUnstakeDeregister.ts
+++ b/packages/dedot-api/src/tx/fastUnstakeDeregister.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { DedotClient } from 'dedot'
-import type { StakingChain } from '../types'
+import type { FastUnstakeChain } from '../types'
 import { asTx } from '../util'
 
-export const fastUnstakeDeregister = <T extends StakingChain>(
+export const fastUnstakeDeregister = <T extends FastUnstakeChain>(
 	api: DedotClient<T>,
 ) => asTx(api.tx.fastUnstake.deregister())

--- a/packages/dedot-api/src/tx/fastUnstakeRegister.ts
+++ b/packages/dedot-api/src/tx/fastUnstakeRegister.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { DedotClient } from 'dedot'
-import type { StakingChain } from '../types'
+import type { FastUnstakeChain } from '../types'
 import { asTx } from '../util'
 
-export const fastUnstakeRegister = <T extends StakingChain>(
+export const fastUnstakeRegister = <T extends FastUnstakeChain>(
 	api: DedotClient<T>,
 ) => asTx(api.tx.fastUnstake.registerFastUnstake())

--- a/packages/dedot-api/src/types/index.ts
+++ b/packages/dedot-api/src/types/index.ts
@@ -45,6 +45,9 @@ export type AssetHubChain =
 // Chains that are used for staking and nomination pools
 export type StakingChain = PolkadotApi | KusamaAssetHubApi | WestendAssetHubApi
 
+// Chains that are used for fast unstake
+export type FastUnstakeChain = PolkadotApi | KusamaApi | WestendAssetHubApi
+
 // Mapping of service types for each network
 export interface ServiceType {
 	polkadot: typeof PolkadotService
@@ -54,9 +57,14 @@ export interface ServiceType {
 
 // Mapping of the required chains for each service
 export type Service = {
-	polkadot: [PolkadotApi, PolkadotPeopleApi, PolkadotAssetHubApi]
-	kusama: [KusamaApi, KusamaPeopleApi, KusamaAssetHubApi]
-	westend: [WestendApi, WestendPeopleApi, WestendAssetHubApi]
+	polkadot: [PolkadotApi, PolkadotPeopleApi, PolkadotAssetHubApi, PolkadotApi]
+	kusama: [KusamaApi, KusamaPeopleApi, KusamaAssetHubApi, KusamaApi]
+	westend: [
+		WestendApi,
+		WestendPeopleApi,
+		WestendAssetHubApi,
+		WestendAssetHubApi,
+	]
 }
 
 // Generic service class that all services must implement

--- a/packages/dedot-api/src/types/index.ts
+++ b/packages/dedot-api/src/types/index.ts
@@ -43,7 +43,7 @@ export type AssetHubChain =
 	| WestendAssetHubApi
 
 // Chains that are used for staking and nomination pools
-export type StakingChain = PolkadotApi | KusamaApi | WestendAssetHubApi
+export type StakingChain = PolkadotApi | KusamaAssetHubApi | WestendAssetHubApi
 
 // Mapping of service types for each network
 export interface ServiceType {

--- a/packages/global-bus/src/fastUnstakeConfig/default.ts
+++ b/packages/global-bus/src/fastUnstakeConfig/default.ts
@@ -4,6 +4,7 @@
 import type { FastUnstakeConfig } from 'types'
 
 export const defaultFastUnstakeConfig: FastUnstakeConfig = {
+	erasToCheckPerBlock: 0,
 	head: {
 		stashes: [],
 		checked: [],

--- a/packages/global-bus/src/stakingMetrics/default.ts
+++ b/packages/global-bus/src/stakingMetrics/default.ts
@@ -5,7 +5,6 @@ import type { StakingMetrics } from 'types'
 
 export const defaultStakingMetrics: StakingMetrics = {
 	totalIssuance: 0n,
-	erasToCheckPerBlock: 0,
 	minimumActiveStake: 0n,
 	counterForValidators: 0,
 	maxValidatorsCount: undefined,

--- a/packages/types/src/fastUnstake.ts
+++ b/packages/types/src/fastUnstake.ts
@@ -4,6 +4,7 @@
 import type { AccountId32 } from 'dedot/codecs'
 
 export interface FastUnstakeConfig {
+	erasToCheckPerBlock: number
 	head: FastUnstakeHead
 	counterForQueue: number
 }

--- a/packages/types/src/networks.ts
+++ b/packages/types/src/networks.ts
@@ -83,7 +83,6 @@ export interface PoolsConfig {
 
 export interface StakingMetrics {
 	totalIssuance: bigint
-	erasToCheckPerBlock: number
 	minimumActiveStake: bigint
 	counterForValidators: number
 	maxValidatorsCount: number | undefined


### PR DESCRIPTION
Prepares the codebase for Kusama AssetHub migration support.

- Updates Kusama's staking chain to `KusamaAssetHubApi`, updates apis being passed into api calls.
- Fast unstake stays on Kusama relay chain - a new `FastUnstakeChain` abstraction has been added.
- `FastUnstakeConsts` has been abstracted to fetch them from the correct chains per network.
- Added `fastUnstakeApi` to `SubscriptionManager` and fixed fast unstake queries.
- Moved fast unstake txs to `FastUnstakeChain`.
- `FastUnstakeConfigQuery ` takes FastUnstakeApi instead of `StakingApi`.
- Moved `erasToCheckPerBlock` to `FastUnstakeConfig`