### PR TITLE
feat: Force disable plugins per network, disable Staking API on Kusama, Westend

### DIFF
--- a/packages/app/src/contexts/Plugins/index.tsx
+++ b/packages/app/src/contexts/Plugins/index.tsx
@@ -21,25 +21,26 @@ export const PluginsProvider = ({ children }: { children: ReactNode }) => {
 	const { isReady, activeEra } = useApi()
 	const { activeAddress } = useActiveAccounts()
 
-	const { activePlugins } = getAvailablePlugins()
+	const { allPlugins, activePlugins } = getAvailablePlugins()
 
 	// Store the currently active plugins
 	const [plugins, setPluginsState] = useState<Plugin[]>(activePlugins)
 
 	// Toggle a plugin
 	const togglePlugin = (key: Plugin) => {
-		let { allPlugins } = getAvailablePlugins()
-
-		if (allPlugins.find((p) => p === key)) {
-			allPlugins = allPlugins.filter((p) => p !== key)
+		let newAllPlugins = [...allPlugins]
+		if (newAllPlugins.find((p) => p === key)) {
+			newAllPlugins = newAllPlugins.filter((p) => p !== key)
 		} else {
-			allPlugins.push(key)
+			newAllPlugins.push(key)
 		}
 
 		// Filter disabled plugins for this network
 		const disabledPlugins = DisabledPluginsPerNetwork[network] || []
-		const activePlugins = allPlugins.filter((p) => !disabledPlugins.includes(p))
-		setPlugins(allPlugins, activePlugins)
+		const newActivePlugins = newAllPlugins.filter(
+			(p) => !disabledPlugins.includes(p),
+		)
+		setPlugins(newAllPlugins, newActivePlugins)
 	}
 
 	// Check if a plugin is currently enabled

--- a/packages/app/src/library/Headers/Popovers/MenuPopover/index.tsx
+++ b/packages/app/src/library/Headers/Popovers/MenuPopover/index.tsx
@@ -20,7 +20,10 @@ import { capitalizeFirstLetter } from '@w3ux/utils'
 import DiscordSVG from 'assets/brands/discord.svg?react'
 import EnvelopeSVG from 'assets/icons/envelope.svg?react'
 import { GitHubURl } from 'consts'
-import { CompulsoryPluginsProduction, PluginsList } from 'consts/plugins'
+import {
+	CompulsoryPluginsProduction,
+	DisabledPluginsPerNetwork,
+} from 'consts/plugins'
 import { getRelayChainData } from 'consts/util/chains'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { useBalances } from 'contexts/Balances'
@@ -55,8 +58,16 @@ export const MenuPopover = ({
 	const { membership } = getPoolMembership(activeAddress)
 	const popoverRef = useRef<HTMLDivElement>(null)
 
+	const forceDisabledPlugins = DisabledPluginsPerNetwork[network] || []
+	const forcePluginsProduction = import.meta.env.PROD
+		? CompulsoryPluginsProduction.filter(
+				(p) => !forceDisabledPlugins.includes(p),
+			)
+		: CompulsoryPluginsProduction
+
+	const pluginsAvailable = forcePluginsProduction.length > 0
+
 	const notStaking = !isNominator && !membership
-	const showPlugins = CompulsoryPluginsProduction.length < PluginsList.length
 
 	// Close the menu if clicked outside of its container
 	useOutsideAlerter(popoverRef, () => {
@@ -152,7 +163,7 @@ export const MenuPopover = ({
 					openModal({ key: 'Invite', size: 'sm' })
 				}}
 			/>
-			{(showPlugins || !import.meta.env.PROD) && (
+			{(pluginsAvailable || !import.meta.env.PROD) && (
 				<DefaultButton
 					text={t('plugins', { ns: 'modals' })}
 					iconLeft={faPuzzlePiece}

--- a/packages/app/src/modals/Plugins/index.tsx
+++ b/packages/app/src/modals/Plugins/index.tsx
@@ -1,7 +1,12 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { CompulsoryPluginsProduction, PluginsList } from 'consts/plugins'
+import {
+	CompulsoryPluginsProduction,
+	DisabledPluginsPerNetwork,
+	PluginsList,
+} from 'consts/plugins'
+import { useNetwork } from 'contexts/Network'
 import { usePlugins } from 'contexts/Plugins'
 import { Title } from 'library/Modal/Title'
 import { useTranslation } from 'react-i18next'
@@ -9,8 +14,11 @@ import { ButtonModal } from 'ui-buttons'
 import { ButtonList, Padding } from 'ui-core/modal'
 
 export const Plugins = () => {
+	const { network } = useNetwork()
 	const { plugins, togglePlugin } = usePlugins()
 	const { t } = useTranslation()
+
+	const disabledPlugins = DisabledPluginsPerNetwork[network] || []
 
 	return (
 		<>
@@ -31,6 +39,7 @@ export const Plugins = () => {
 							<ButtonModal
 								key={plugin}
 								label={'toggle'}
+								disabled={disabledPlugins.includes(plugin)}
 								selected={plugins.includes(plugin)}
 								text={t(`plugin.${plugin}`, { ns: 'app' })}
 								onClick={() => togglePlugin(plugin)}

--- a/packages/consts/src/plugins.ts
+++ b/packages/consts/src/plugins.ts
@@ -22,6 +22,8 @@ export const CompulsoryPluginsProduction: Plugin[] = [
 export const DisabledPluginsPerNetwork: Partial<Record<NetworkId, Plugin[]>> = {
 	// NOTE: During Kusama asset hub migration, disable the staking API until it is fixed
 	kusama: ['staking_api'],
+	// NOTE: Westend is not supported by the staking API plugin
+	westend: ['staking_api'],
 }
 
 export const PolkawatchConfig = {

--- a/packages/consts/src/plugins.ts
+++ b/packages/consts/src/plugins.ts
@@ -1,7 +1,9 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { Plugin } from 'types'
+import type { NetworkId, Plugin } from 'types'
+
+export const PluginsList: Plugin[] = ['staking_api', 'subscan', 'polkawatch']
 
 // Force plugins to be enabled in production environment
 //
@@ -13,7 +15,14 @@ export const CompulsoryPluginsProduction: Plugin[] = [
 	'polkawatch',
 ]
 
-export const PluginsList: Plugin[] = ['staking_api', 'subscan', 'polkawatch']
+// Force plugins to be disabled in production environment on a per-network basis
+//
+// NOTE: If you are forking the staking dashboard and do not wish to enforce a plugin to be
+// disabled, you can remove it from this list
+export const DisabledPluginsPerNetwork: Partial<Record<NetworkId, Plugin[]>> = {
+	// NOTE: During Kusama asset hub migration, disable the staking API until it is fixed
+	kusama: ['staking_api'],
+}
 
 export const PolkawatchConfig = {
 	ApiVersion: 'v2',

--- a/packages/consts/src/util/networks.ts
+++ b/packages/consts/src/util/networks.ts
@@ -21,3 +21,7 @@ export const getEnabledNetworks = (): Networks =>
 // Checks if a network is enabled
 export const isNetworkEnabled = (network: NetworkId) =>
 	Object.keys(getEnabledNetworks()).includes(network)
+
+// Checks if a network is valid key of `NetworkList`
+export const isValidNetwork = (network: string): network is NetworkId =>
+	Object.keys(NetworkList).includes(network)

--- a/packages/global-bus/src/plugins/index.ts
+++ b/packages/global-bus/src/plugins/index.ts
@@ -6,11 +6,9 @@ import { _plugins } from './private'
 
 export const plugins$ = _plugins.asObservable()
 
-export const getPlugins = () => _plugins.getValue()
-
-export const setPlugins = (plugins: Plugin[]) => {
-	localStorage.setItem('plugins', JSON.stringify(plugins))
-	_plugins.next(plugins)
+export const setPlugins = (allPlugins: Plugin[], activePlugins: Plugin[]) => {
+	localStorage.setItem('plugins', JSON.stringify(allPlugins))
+	_plugins.next(activePlugins)
 }
 
 export const pluginEnabled = (key: Plugin) => _plugins.getValue().includes(key)

--- a/packages/global-bus/src/plugins/local.ts
+++ b/packages/global-bus/src/plugins/local.ts
@@ -37,9 +37,9 @@ export const getAvailablePlugins = () => {
 	const networkDisabledPlugins = DisabledPluginsPerNetwork[localNetwork] || []
 
 	// Filter out disabled plugins for this network
-	const activePlugins: Plugin[] = [...allPlugins]
-	const activePlugins: Plugin[] = allPlugins.filter(
-		(plugin) => !networkDisabledPlugins.includes(plugin)
+	let activePlugins: Plugin[] = [...allPlugins]
+	activePlugins = activePlugins.filter(
+		(plugin) => !networkDisabledPlugins.includes(plugin),
 	)
 
 	return { allPlugins, activePlugins }

--- a/packages/global-bus/src/plugins/private.ts
+++ b/packages/global-bus/src/plugins/private.ts
@@ -5,4 +5,5 @@ import { BehaviorSubject } from 'rxjs'
 import type { Plugin } from 'types'
 import { getAvailablePlugins } from './local'
 
-export const _plugins = new BehaviorSubject<Plugin[]>(getAvailablePlugins())
+const { activePlugins } = getAvailablePlugins()
+export const _plugins = new BehaviorSubject<Plugin[]>(activePlugins)


### PR DESCRIPTION
This PR introduces the ability to force disable plugins on a per-network basis, allowing specific plugins to be disabled for certain network configurations. This is particularly useful for handling cases where certain plugins may not be available or functional on specific networks.

Key changes:
- Added `DisabledPluginsPerNetwork` configuration to disable plugins by network
- Updated plugin loading logic to filter out disabled plugins per network
- Modified UI components to show disabled plugins as non-interactive

The Staking API is no longer supporting the Westend network, and is now disabled.
The Staking API has temporarily been disabled for Kusama while support for the Asset Hub migration is undergoing.